### PR TITLE
Fix bitmap length

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ spec := &MessageSpec{
 			Pref:        prefix.ASCII.Fixed,
 		}),
 		1: field.NewBitmap(&field.Spec{
-			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -16,7 +16,7 @@ type Bitmap struct {
 func NewBitmap(spec *Spec) Field {
 	return &Bitmap{
 		spec:   spec,
-		bitmap: utils.NewBitmap(128),
+		bitmap: utils.NewBitmap(192),
 	}
 }
 
@@ -67,48 +67,49 @@ func (f *Bitmap) Pack() ([]byte, error) {
 // Unpack of the Bitmap field returns data of varied length
 // if there is only primary bitmap (bit 1 is not set) we return only 8 bytes
 // if secondary bitmap presents (bit 1 is set) we return 16 bytes
+
+const minBitmapLength = 8 // 64 bit, 8 bytes, or 16 hex digits
+const maxBitmaps = 3
+
 func (f *Bitmap) Unpack(data []byte) (int, error) {
-	minLen, err := f.spec.Pref.DecodeLength(f.spec.Length/2, data)
+	minLen, err := f.spec.Pref.DecodeLength(minBitmapLength, data)
 	if err != nil {
 		return 0, fmt.Errorf("failed to decode length: %v", err)
 	}
 
-	dataLen, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+	rawBitmap := make([]byte, 0)
+	read := 0
+
+	// read max
+	for i := 0; i < maxBitmaps; i++ {
+		start := i * minLen
+		end := (i + 1) * minLen
+
+		if len(data) < end {
+			return 0, fmt.Errorf("not enough data to read %d bitmap", i+1)
+		}
+
+		decoded, err := f.spec.Enc.Decode(data[start:end], 0)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode content: %v", err)
+		}
+		read += minLen
+
+		rawBitmap = append(rawBitmap, decoded...)
+		bitmap := utils.NewBitmapFromData(decoded)
+
+		// if no more bitmaps, exit loop
+		if !bitmap.IsSet(1) {
+			break
+		}
 	}
 
-	if len(data) < minLen {
-		return 0, fmt.Errorf("expected min data length is %d, but it is %d", minLen, len(data))
-	}
-
-	// read minLen first. for cases when there is only primary bitmap
-	start := f.spec.Pref.Length()
-	end := f.spec.Pref.Length() + minLen
-	raw, err := f.spec.Enc.Decode(data[start:end], 0)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
-	}
-
-	bitmap := utils.NewBitmapFromData(raw)
-	if !bitmap.IsSet(1) {
-		f.bitmap = bitmap
-		return minLen, nil
-	}
-
-	// read full lenth. for cases when there is secondary bitmap
-	end = f.spec.Pref.Length() + dataLen
-	raw, err = f.spec.Enc.Decode(data[start:end], 0)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
-	}
-
-	f.bitmap = utils.NewBitmapFromData(raw)
-	return dataLen, nil
+	f.bitmap = utils.NewBitmapFromData(rawBitmap)
+	return read, nil
 }
 
 func (f *Bitmap) Reset() {
-	f.bitmap = utils.NewBitmap(128)
+	f.bitmap = utils.NewBitmap(192)
 }
 
 func (f *Bitmap) Set(i int) {

--- a/field/bitmap_test.go
+++ b/field/bitmap_test.go
@@ -6,10 +6,89 @@ import (
 
 	"github.com/moov-io/iso8583/encoding"
 	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/utils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHexBitmap(t *testing.T) {
+	// test
+	// when there is only fields for the first bitmap
+	// then the legth of the bitmap should be 16 (hex)
+	// when there are fields for the second bitmap
+	// then the length of the bitmap should be 32
+	// when there are fields for the third bitmap
+	// then the length of the bitmap should be 48
+
+	// b1.Set(10)
+	// 004000000000000000000000000000000000000000000000
+
+	// b2.Set(1) //second bitmap presents
+	// b2.Set(10)
+	// b2.Set(70)
+	// 804000000000000004000000000000000000000000000000
+
+	// b3.Set(1)  //second bitmap presents
+	// b3.Set(65) //third bitmap presents
+	// b3.Set(10)
+	// b3.Set(140)
+	// 804000000000000080000000000000000010000000000000
+	t.Run("Read only first bitmap", func(t *testing.T) {
+		field := &Bitmap{
+			spec: &Spec{
+				Description: "Bitmap",
+				Enc:         encoding.Hex,
+				Pref:        prefix.Hex.Fixed,
+			},
+			bitmap: utils.NewBitmap(192),
+		}
+
+		read, err := field.Unpack([]byte("004000000000000000000000000000000000000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 16, read)
+
+		require.True(t, field.IsSet(10))
+	})
+
+	t.Run("Read two bitmaps", func(t *testing.T) {
+		field := &Bitmap{
+			spec: &Spec{
+				Description: "Bitmap",
+				Enc:         encoding.Hex,
+				Pref:        prefix.Hex.Fixed,
+			},
+			bitmap: utils.NewBitmap(192),
+		}
+
+		read, err := field.Unpack([]byte("804000000000000004000000000000000000000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 32, read)
+
+		require.True(t, field.IsSet(10))
+		require.True(t, field.IsSet(70))
+	})
+
+	t.Run("Read three bitmaps", func(t *testing.T) {
+		field := &Bitmap{
+			spec: &Spec{
+				Length:      16,
+				Description: "Bitmap",
+				Enc:         encoding.Hex,
+				Pref:        prefix.Hex.Fixed,
+			},
+			bitmap: utils.NewBitmap(192),
+		}
+
+		read, err := field.Unpack([]byte("804000000000000080000000000000000010000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 48, read)
+
+		require.True(t, field.IsSet(10))
+		require.True(t, field.IsSet(140))
+	})
+
 	t.Run("when not enough data to unpack", func(t *testing.T) {
 		field := NewBitmap(&Spec{
 			Length:      16,
@@ -20,35 +99,22 @@ func TestHexBitmap(t *testing.T) {
 		_, err := field.Unpack([]byte("4000"))
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "expected min data length is 16, but it is 4")
+		require.Contains(t, err.Error(), "not enough data to read 1 bitmap")
 	})
 
-	t.Run("decode primary bitmap", func(t *testing.T) {
+	t.Run("when bit for secondary bitmap is set but not enough data to read", func(t *testing.T) {
 		field := NewBitmap(&Spec{
 			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
-		// bits 2, 20 are set
-		length, err := field.Unpack([]byte("4000100000000000"))
+		// bits 2, 20, 65, 120 are set, but no data for third bitmap
+		_, err := field.Unpack([]byte("c0001000000000008000000000000100"))
 
-		require.NoError(t, err)
-		require.Equal(t, length, 16)
-	})
-
-	t.Run("decode primary and secondary bitmap", func(t *testing.T) {
-		field := NewBitmap(&Spec{
-			Length:      16,
-			Description: "Bitmap",
-			Enc:         encoding.Hex,
-			Pref:        prefix.Hex.Fixed,
-		})
-		// bits 2, 20, 65,120 are set
-		length, err := field.Unpack([]byte("c0001000000000008000000000000100"))
-
-		require.NoError(t, err)
-		require.Equal(t, length, 32)
+		// error
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not enough data to read 3 bitmap")
 	})
 
 	t.Run("with primary bitmap only it returns only half of the full length", func(t *testing.T) {

--- a/field/bitmap_test.go
+++ b/field/bitmap_test.go
@@ -1,101 +1,77 @@
 package field
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/moov-io/iso8583/encoding"
 	"github.com/moov-io/iso8583/prefix"
-	"github.com/moov-io/iso8583/utils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHexBitmap(t *testing.T) {
-	// test
-	// when there is only fields for the first bitmap
-	// then the legth of the bitmap should be 16 (hex)
-	// when there are fields for the second bitmap
-	// then the length of the bitmap should be 32
-	// when there are fields for the third bitmap
-	// then the length of the bitmap should be 48
-
-	// b1.Set(10)
-	// 004000000000000000000000000000000000000000000000
-
-	// b2.Set(1) //second bitmap presents
-	// b2.Set(10)
-	// b2.Set(70)
-	// 804000000000000004000000000000000000000000000000
-
-	// b3.Set(1)  //second bitmap presents
-	// b3.Set(65) //third bitmap presents
-	// b3.Set(10)
-	// b3.Set(140)
-	// 804000000000000080000000000000000010000000000000
 	t.Run("Read only first bitmap", func(t *testing.T) {
-		field := &Bitmap{
-			spec: &Spec{
-				Description: "Bitmap",
-				Enc:         encoding.Hex,
-				Pref:        prefix.Hex.Fixed,
-			},
-			bitmap: utils.NewBitmap(192),
-		}
-
-		read, err := field.Unpack([]byte("004000000000000000000000000000000000000000000000"))
-
-		require.NoError(t, err)
-		require.Equal(t, 16, read)
-
-		require.True(t, field.IsSet(10))
-	})
-
-	t.Run("Read two bitmaps", func(t *testing.T) {
-		field := &Bitmap{
-			spec: &Spec{
-				Description: "Bitmap",
-				Enc:         encoding.Hex,
-				Pref:        prefix.Hex.Fixed,
-			},
-			bitmap: utils.NewBitmap(192),
-		}
-
-		read, err := field.Unpack([]byte("804000000000000004000000000000000000000000000000"))
-
-		require.NoError(t, err)
-		require.Equal(t, 32, read)
-
-		require.True(t, field.IsSet(10))
-		require.True(t, field.IsSet(70))
-	})
-
-	t.Run("Read three bitmaps", func(t *testing.T) {
-		field := &Bitmap{
-			spec: &Spec{
-				Length:      16,
-				Description: "Bitmap",
-				Enc:         encoding.Hex,
-				Pref:        prefix.Hex.Fixed,
-			},
-			bitmap: utils.NewBitmap(192),
-		}
-
-		read, err := field.Unpack([]byte("804000000000000080000000000000000010000000000000"))
-
-		require.NoError(t, err)
-		require.Equal(t, 48, read)
-
-		require.True(t, field.IsSet(10))
-		require.True(t, field.IsSet(140))
-	})
-
-	t.Run("when not enough data to unpack", func(t *testing.T) {
 		field := NewBitmap(&Spec{
-			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
+
+		// set bit: 10
+		read, err := field.Unpack([]byte("004000000000000000000000000000000000000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 16, read) // 16 is 8 bytes (one bitmap) encoded in hex
+
+		bitmap := field.(*Bitmap)
+
+		require.True(t, bitmap.IsSet(10))
+	})
+
+	t.Run("Read two bitmaps", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Hex,
+			Pref:        prefix.Hex.Fixed,
+		})
+
+		// set bits: 1, 10, 70
+		read, err := field.Unpack([]byte("804000000000000004000000000000000000000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 32, read) // 32 is 16 bytes (two bitmaps) encoded in hex
+
+		bitmap := field.(*Bitmap)
+
+		require.True(t, bitmap.IsSet(10))
+		require.True(t, bitmap.IsSet(70))
+	})
+
+	t.Run("Read three bitmaps", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Hex,
+			Pref:        prefix.Hex.Fixed,
+		})
+
+		read, err := field.Unpack([]byte("804000000000000080000000000000000010000000000000"))
+
+		require.NoError(t, err)
+		require.Equal(t, 48, read) // 48 is 24 bytes (three bitmaps) encoded in hex
+
+		bitmap := field.(*Bitmap)
+
+		// set bits: 1, 10, 65, 140
+		require.True(t, bitmap.IsSet(10))
+		require.True(t, bitmap.IsSet(140))
+	})
+
+	t.Run("when not enough data to unpack", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Hex,
+			Pref:        prefix.Hex.Fixed,
+		})
+
 		_, err := field.Unpack([]byte("4000"))
 
 		require.Error(t, err)
@@ -104,11 +80,11 @@ func TestHexBitmap(t *testing.T) {
 
 	t.Run("when bit for secondary bitmap is set but not enough data to read", func(t *testing.T) {
 		field := NewBitmap(&Spec{
-			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
+
 		// bits 2, 20, 65, 120 are set, but no data for third bitmap
 		_, err := field.Unpack([]byte("c0001000000000008000000000000100"))
 
@@ -117,9 +93,8 @@ func TestHexBitmap(t *testing.T) {
 		require.Contains(t, err.Error(), "not enough data to read 3 bitmap")
 	})
 
-	t.Run("with primary bitmap only it returns only half of the full length", func(t *testing.T) {
+	t.Run("with primary bitmap only it returns signle bitmap length", func(t *testing.T) {
 		field := NewBitmap(&Spec{
-			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
@@ -127,21 +102,16 @@ func TestHexBitmap(t *testing.T) {
 
 		bitmap := field.(*Bitmap)
 
-		// first 64 bits are referred to as the primary bit map
-		bitmap.Set(2)
-		bitmap.Set(20)
+		bitmap.Set(20) // first bitmap field
 
 		data, err := bitmap.Pack()
 
-		fmt.Println("str", string(data))
-
 		require.NoError(t, err)
-		require.Len(t, data, 16)
+		require.Len(t, data, 16) // 16 bytes is 8 bytes (one bitmap) encoded in hex
 	})
 
-	t.Run("with secondary bitmap only it returns only half of the full length", func(t *testing.T) {
+	t.Run("with secondary bitmap it returns length of two bitmaps", func(t *testing.T) {
 		field := NewBitmap(&Spec{
-			Length:      16,
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
@@ -149,33 +119,46 @@ func TestHexBitmap(t *testing.T) {
 
 		bitmap := field.(*Bitmap)
 
-		// first 64 bits are referred to as the primary bit map
-		bitmap.Set(2)
-		bitmap.Set(20)
-		bitmap.Set(65)
-		bitmap.Set(120)
+		bitmap.Set(20) // first bitmap field
+		bitmap.Set(70) // second bitmap field
 
 		data, err := bitmap.Pack()
 
 		require.NoError(t, err)
-		require.Len(t, data, 32)
+		require.Len(t, data, 32) // 32 bytes is 16 bytes (two bitmaps) encoded in hex
+	})
+
+	t.Run("with third bitmap it returns length of three bitmaps", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Hex,
+			Pref:        prefix.Hex.Fixed,
+		})
+
+		bitmap := field.(*Bitmap)
+
+		bitmap.Set(20)  // first bitmap field
+		bitmap.Set(70)  // second bitmap field
+		bitmap.Set(150) // third bitmap field
+
+		data, err := bitmap.Pack()
+
+		require.NoError(t, err)
+		require.Len(t, data, 48) // 48 bytes is 24 bytes (three bitmaps) encoded in hex
 	})
 }
 
 func TestBinaryBitmap(t *testing.T) {
-	field := NewBitmap(&Spec{
-		Length:      16,
-		Description: "Bitmap",
-		Enc:         encoding.Binary,
-		Pref:        prefix.Binary.Fixed,
-	})
+	t.Run("with primary bitmap only it returns signle bitmap length", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Binary,
+			Pref:        prefix.Binary.Fixed,
+		})
 
-	bitmap := field.(*Bitmap)
+		bitmap := field.(*Bitmap)
 
-	t.Run("with primary bitmap only it returns only half of the full length", func(t *testing.T) {
-		// first 64 bits are referred to as the primary bit map
-		bitmap.Set(2)
-		bitmap.Set(20)
+		bitmap.Set(20) // first bitmap field
 
 		data, err := bitmap.Pack()
 
@@ -183,16 +166,40 @@ func TestBinaryBitmap(t *testing.T) {
 		require.Len(t, data, 8)
 	})
 
-	t.Run("with secondary bitmap only it returns only half of the full length", func(t *testing.T) {
-		// bits 65 through 128 are referred to as the secondary bit map
-		bitmap.Set(2)
-		bitmap.Set(20)
-		bitmap.Set(65)
-		bitmap.Set(120)
+	t.Run("with secondary bitmap it returns length of two bitmaps", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Binary,
+			Pref:        prefix.Binary.Fixed,
+		})
+
+		bitmap := field.(*Bitmap)
+
+		bitmap.Set(20) // first bitmap field
+		bitmap.Set(70) // second bitmap field
 
 		data, err := bitmap.Pack()
 
 		require.NoError(t, err)
 		require.Len(t, data, 16)
+	})
+
+	t.Run("with third bitmap it returns length of three bitmaps", func(t *testing.T) {
+		field := NewBitmap(&Spec{
+			Description: "Bitmap",
+			Enc:         encoding.Binary,
+			Pref:        prefix.Binary.Fixed,
+		})
+
+		bitmap := field.(*Bitmap)
+
+		bitmap.Set(20)  // first bitmap field
+		bitmap.Set(70)  // second bitmap field
+		bitmap.Set(150) // third bitmap field
+
+		data, err := bitmap.Pack()
+
+		require.NoError(t, err)
+		require.Len(t, data, 24)
 	})
 }

--- a/message_spec_test.go
+++ b/message_spec_test.go
@@ -20,7 +20,6 @@ func TestMessageSpec_CreateMessageFields(t *testing.T) {
 				Pref:        prefix.ASCII.Fixed,
 			}),
 			1: field.NewBitmap(&field.Spec{
-				Length:      16,
 				Description: "Bitmap",
 				Enc:         encoding.Hex,
 				Pref:        prefix.Hex.Fixed,

--- a/message_test.go
+++ b/message_test.go
@@ -22,7 +22,6 @@ func TestMessage(t *testing.T) {
 				Pref:        prefix.ASCII.Fixed,
 			}),
 			1: field.NewBitmap(&field.Spec{
-				Length:      16,
 				Description: "Bitmap",
 				Enc:         encoding.Hex,
 				Pref:        prefix.Hex.Fixed,
@@ -134,7 +133,6 @@ func TestPackUnpack(t *testing.T) {
 				Pref:        prefix.ASCII.Fixed,
 			}),
 			1: field.NewBitmap(&field.Spec{
-				Length:      16,
 				Description: "Bitmap",
 				Enc:         encoding.Binary,
 				Pref:        prefix.ASCII.Fixed,

--- a/utils/bitmap_test.go
+++ b/utils/bitmap_test.go
@@ -29,5 +29,4 @@ func TestBitmap(t *testing.T) {
 	bitmap3.Set(11)
 	bitmap3.Set(15)
 	require.Equal(t, []byte{0xC6, 0x62}, bitmap3.Bytes())
-
 }


### PR DESCRIPTION
@nlakritz, I've fixed how Bitmap works.

Setting the length for the bitmap was wrong. Its length depends on the data it reads or generates:
* when we pack message, we know how many bitmaps we need to pack our data
* when we unpack the message, we have to read 8 bytes and check if bit 1 is set, then read 8 next bytes and if bit 1 is set, read the next 8 bytes, and so on.

I'm merging this PR into the `new-version` branch, so you may pull it and update docs if necessary.