### PR TITLE
Fix zero-padded numeric value 0 unpack error

### DIFF
--- a/field/numeric.go
+++ b/field/numeric.go
@@ -85,7 +85,7 @@ func (f *Numeric) Unpack(data []byte) (int, error) {
 	if len(raw) == 0 {
 		// for a length 0 raw, string(raw) would become "" which makes Atoi return an error
 		// however for example "0000" (value 0 left-padded with '0') should have 0 as output, not an error
-		// so if the lenght of raw is 0, set f.Value to 0 instead of parsing the raw
+		// so if the length of raw is 0, set f.Value to 0 instead of parsing the raw
 		f.Value = 0
 	} else {
 		// otherwise parse the raw to an int

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -82,9 +82,17 @@ func (f *Numeric) Unpack(data []byte) (int, error) {
 		raw = f.spec.Pad.Unpad(raw)
 	}
 
-	f.Value, err = strconv.Atoi(string(raw))
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert into number: %v", err)
+	if len(raw) == 0 {
+		// for a length 0 raw, string(raw) would become "" which makes Atoi return an error
+		// however for example "0000" (value 0 left-padded with '0') should have 0 as output, not an error
+		// so if the lenght of raw is 0, set f.Value to 0 instead of parsing the raw
+		f.Value = 0
+	} else {
+		// otherwise parse the raw to an int
+		f.Value, err = strconv.Atoi(string(raw))
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert into number: %v", err)
+		}
 	}
 
 	return read + f.spec.Pref.Length(), nil

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -60,3 +60,30 @@ func TestNumericFieldWithNotANumber(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to convert into number")
 }
+
+func TestNumericFieldZeroLeftPaddedZero(t *testing.T) {
+	field := NewNumeric(&Spec{
+		Length:      4,
+		Description: "Field",
+		Enc:         encoding.ASCII,
+		Pref:        prefix.ASCII.Fixed,
+		Pad:         padding.Left('0'),
+	})
+
+	num := field.(*Numeric)
+
+	field.SetBytes([]byte("0"))
+	require.Equal(t, 0, num.Value)
+
+	packed, err := field.Pack()
+
+	require.NoError(t, err)
+	require.Equal(t, "0000", string(packed))
+
+	length, err := field.Unpack([]byte("0000"))
+
+	require.NoError(t, err)
+	require.Equal(t, 4, length)
+	require.Equal(t, "0", string(field.Bytes()))
+	require.Equal(t, 0, num.Value)
+}


### PR DESCRIPTION
Unpacking a Numeric field with value 0 that is left-padded with '0' returns an error from the Unpack method instead of setting the expected value 0.

**Example**
For the following specification:
```go
field.NewNumeric(&field.Spec{
	Length:      4,
	Description: "Example",
	Enc:         encoding.ASCII,
	Pref:        prefix.ASCII.Fixed,
	Pad:         padding.Left('0'),
})
```
If the value of this Numeric field is set to 0, then in the Pack method after padding will have "0000".
When unpacking the packed output however, the Unpad method in Unpack removes all characters.
The input value to the Atoi is then "" so Atoi will return an error.
The expected output is the original input value of 0 instead of an error.

This PR fixes this bug by only parsing the raw if the length is not 0, otherwise the value is set to 0.
Let me know if I should also create an issue for this.