### PR TITLE
Add network header

### DIFF
--- a/network/ascii_4bytes_header.go
+++ b/network/ascii_4bytes_header.go
@@ -1,0 +1,50 @@
+package network
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+var _ Header = (*ASCII4BytesHeader)(nil)
+
+// ASCII4BytesHeader is 4 bytes ASCII encoded length
+type ASCII4BytesHeader struct {
+	Len int
+}
+
+func NewASCII4BytesHeader() *ASCII4BytesHeader {
+	return &ASCII4BytesHeader{}
+}
+
+func (h *ASCII4BytesHeader) SetLength(length int) {
+	h.Len = length
+}
+
+func (h *ASCII4BytesHeader) Length() int {
+	return h.Len
+}
+
+func (h *ASCII4BytesHeader) WriteTo(w io.Writer) (int, error) {
+	return fmt.Fprintf(w, "%04d", h.Len)
+}
+
+func (h *ASCII4BytesHeader) ReadFrom(r io.Reader) (int, error) {
+	buf := make([]byte, 4)
+	read, err := io.ReadFull(r, buf)
+	if err != nil {
+		return 0, fmt.Errorf("reading header: %v", err)
+	}
+
+	if read != 4 {
+		return 0, fmt.Errorf("expected to read 4 bytes of the header, got: %v", read)
+	}
+
+	l, err := strconv.Atoi(string(buf))
+	if err != nil {
+		return 0, fmt.Errorf("converting header to int: %v", err)
+	}
+	h.Len = l
+
+	return read, nil
+}

--- a/network/ascii_4bytes_header_test.go
+++ b/network/ascii_4bytes_header_test.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestASCII4BytesHeader(t *testing.T) {
+	t.Run("Pack returns ASCII encoded length", func(t *testing.T) {
+		header := NewASCII4BytesHeader()
+
+		header.SetLength(115)
+		var buf bytes.Buffer
+		n, err := header.WriteTo(&buf)
+
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		// len 115 encoded in ASCII
+		require.Equal(t, "0115", buf.String())
+	})
+
+	t.Run("Read reads 4 bytes and decode length from ASCII", func(t *testing.T) {
+		header := NewASCII4BytesHeader()
+
+		// len 115 encoded in ASCII
+		packed := []byte("0115")
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.NoError(t, err)
+		require.Equal(t, 115, header.Length())
+	})
+
+	t.Run("Read returns error when not enough data to read", func(t *testing.T) {
+		header := NewASCII4BytesHeader()
+
+		// len 115 encoded in ASCII
+		packed := []byte("011")
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.Error(t, err)
+	})
+}

--- a/network/bcd_2bytes.go
+++ b/network/bcd_2bytes.go
@@ -1,0 +1,60 @@
+package network
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/moov-io/iso8583/encoding"
+)
+
+var _ Header = (*BCD2BytesHeader)(nil)
+
+// 2 bytes of BCD encoded length
+type BCD2BytesHeader struct {
+	Len int
+}
+
+func NewBCD2BytesHeader() *BCD2BytesHeader {
+	return &BCD2BytesHeader{}
+}
+
+func (h *BCD2BytesHeader) SetLength(length int) {
+	h.Len = length
+}
+
+func (h *BCD2BytesHeader) Length() int {
+	return h.Len
+}
+
+func (h *BCD2BytesHeader) WriteTo(w io.Writer) (int, error) {
+	strLen := fmt.Sprintf("%04d", h.Len)
+	res, err := encoding.BCD.Encode([]byte(strLen))
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(res)
+}
+
+func (h *BCD2BytesHeader) ReadFrom(r io.Reader) (int, error) {
+	buf := make([]byte, 2)
+	read, err := io.ReadFull(r, buf)
+	if err != nil {
+		return 0, fmt.Errorf("reading header: %v", err)
+	}
+
+	// decode 4 digits from the buf
+	bDigits, _, err := encoding.BCD.Decode(buf, 4)
+	if err != nil {
+		return 0, err
+	}
+
+	dataLen, err := strconv.Atoi(string(bDigits))
+	if err != nil {
+		return 0, fmt.Errorf("converting string to int: %v", err)
+	}
+
+	h.Len = dataLen
+
+	return read, nil
+}

--- a/network/bcd_2bytes_test.go
+++ b/network/bcd_2bytes_test.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBCD2BytesHeader(t *testing.T) {
+	t.Run("Pack returns BCD encoded length", func(t *testing.T) {
+		header := NewBCD2BytesHeader()
+
+		header.SetLength(115)
+		var buf bytes.Buffer
+		n, err := header.WriteTo(&buf)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+		// len 115 encoded in BCD
+		require.Equal(t, []byte{0x01, 0x15}, buf.Bytes())
+	})
+
+	t.Run("Read reads 2 bytes and decode length from BCD", func(t *testing.T) {
+		header := NewBCD2BytesHeader()
+
+		// len 115 encoded in BCD
+		packed := []byte{0x01, 0x15}
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.NoError(t, err)
+		require.Equal(t, 115, header.Length())
+	})
+
+	t.Run("Read returns error when not enough data to read", func(t *testing.T) {
+		header := NewBCD2BytesHeader()
+
+		// len 115 encoded in BCD
+		packed := []byte{0x01}
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.Error(t, err)
+	})
+}

--- a/network/header.go
+++ b/network/header.go
@@ -1,0 +1,71 @@
+package network
+
+import (
+	"io"
+)
+
+/*
+Header is the interface for network header
+
+All messages between client/server have a message length header. In some cases
+it can be a 4 bytes ASCII or 2 bytes BCD encoded length.
+
+Here is how you can use it to read message from net.Conn:
+
+	func handleRequest(conn net.Conn) {
+		header := network.NewBCD2BytesHeader()
+		_, err := header.ReadFrom(conn)
+		if err != nil {
+			fmt.Printf("Reading header: %w\n", err)
+		}
+
+		// Make a buffer to hold message
+		buf := make([]byte, header.Length())
+		// Read the incoming connection into the buffer.
+		read, err := conn.Read(buf)
+		if err != nil {
+			fmt.Println("Error reading:", err.Error())
+		}
+		if reqLen != header.Length() {
+			fmt.Println("Expected to read %d bytes, read %d bytes", header.Length(), read)
+		}
+
+		message := iso8583.NewMessage(iso8583.Spec87)
+		message.Unpack(buf)
+
+		// work with the message
+	}
+
+This is how you can write header into the net.Conn:
+
+	header := network.NewBCD2BytesHeader()
+	packed, err := message.Pack()
+	if err != nil {
+		// handle error
+	}
+	header.SetLength(len(packed))
+	_, err = header.WriteTo(conn)
+	if err != nil {
+		// handle error
+	}
+	n, err := conn.Write(packed)
+	if err != nil {
+		// handle error
+	}
+
+*/
+
+// Header is network header interface to write/read encoded message legnth
+type Header interface {
+	// WriteTo encoded length into Writer
+	WriteTo(w io.Writer) (int, error)
+
+	// ReadFrom reads header (N bytes) from the Reader
+	ReadFrom(r io.Reader) (int, error)
+
+	// SetLength sets the length of the message
+	SetLength(length int)
+
+	// Length returns the length of the message
+	Length() int
+}

--- a/network/hex_4bytes_header.go
+++ b/network/hex_4bytes_header.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 )
 
@@ -40,12 +41,16 @@ func (h *Hex4BytesHeader) ReadFrom(r io.Reader) (int, error) {
 		return 0, fmt.Errorf("expected to read 4 bytes of the header, got: %v", read)
 	}
 
-	l, err := strconv.ParseInt(string(buf), 16, 64)
+	parsed, err := strconv.ParseInt(string(buf), 16, 64)
 	if err != nil {
 		return 0, fmt.Errorf("converting hex to int: %v", err)
 	}
 
-	h.Len = int(l)
+	if parsed < 0 || parsed > math.MaxInt32 {
+		return 0, fmt.Errorf("converting parsed integer into smaller bit size than expected: %d", parsed)
+	}
+
+	h.Len = int(parsed)
 
 	return read, nil
 }

--- a/network/hex_4bytes_header.go
+++ b/network/hex_4bytes_header.go
@@ -1,0 +1,51 @@
+package network
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+var _ Header = (*Hex4BytesHeader)(nil)
+
+// Hex4BytesHeader is 4 bytes HEX encoded length
+type Hex4BytesHeader struct {
+	Len int
+}
+
+func NewHex4BytesHeader() *Hex4BytesHeader {
+	return &Hex4BytesHeader{}
+}
+
+func (h *Hex4BytesHeader) SetLength(length int) {
+	h.Len = length
+}
+
+func (h *Hex4BytesHeader) Length() int {
+	return h.Len
+}
+
+func (h *Hex4BytesHeader) WriteTo(w io.Writer) (int, error) {
+	return fmt.Fprintf(w, "%04X", h.Len)
+}
+
+func (h *Hex4BytesHeader) ReadFrom(r io.Reader) (int, error) {
+	buf := make([]byte, 4)
+	read, err := io.ReadFull(r, buf)
+	if err != nil {
+		return 0, fmt.Errorf("reading header: %v", err)
+	}
+
+	if read != 4 {
+		return 0, fmt.Errorf("expected to read 4 bytes of the header, got: %v", read)
+	}
+
+	l, err := strconv.ParseInt(string(buf), 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("converting hex to int: %v", err)
+	}
+
+	h.Len = int(l)
+
+	return read, nil
+}

--- a/network/hex_4bytes_header_test.go
+++ b/network/hex_4bytes_header_test.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHex4BytesHeader(t *testing.T) {
+	t.Run("Pack returns ASCII encoded length", func(t *testing.T) {
+		header := NewHex4BytesHeader()
+
+		header.SetLength(319)
+		var buf bytes.Buffer
+		n, err := header.WriteTo(&buf)
+
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		// len 115 encoded in ASCII
+		require.Equal(t, "013F", buf.String())
+	})
+
+	t.Run("Read reads 4 bytes and decode length from ASCII", func(t *testing.T) {
+		header := NewHex4BytesHeader()
+
+		// len 115 encoded in ASCII
+		packed := []byte("013F")
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.NoError(t, err)
+		require.Equal(t, 319, header.Length())
+	})
+
+	t.Run("Read returns error when not enough data to read", func(t *testing.T) {
+		header := NewHex4BytesHeader()
+
+		// len 115 encoded in ASCII
+		packed := []byte("011")
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.Error(t, err)
+	})
+}

--- a/prefix/bcd.go
+++ b/prefix/bcd.go
@@ -32,7 +32,6 @@ func (p *bcdVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 
 	strLen := fmt.Sprintf("%0*d", p.Digits, dataLen)
 	res, err := encoding.BCD.Encode([]byte(strLen))
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All messages between client/server have a message length header. In some cases, it can be a 4 bytes ASCII or 2 bytes BCD encoded length. With this PR we add the interface and two implementations of the `network.Header`:

```go

// Header is the interface for network header. 
type Header interface {
	// WriteTo encoded length into Writer
	WriteTo(w io.Writer) (int, error)

	// ReadFrom reads header (N bytes) from the Reader
	ReadFrom(r io.Reader) (int, error)

	// SetLength sets the length of the message
	SetLength(length int)

	// Length returns the length of the message
	Length() int
}
```

Here is how you can use it to read message from net.Conn:

```go
func handleRequest(conn net.Conn) {
	header := network.NewBCD2BytesHeader()
	_, err := header.ReadFrom(conn)
	if err != nil {
		// handle error
	}

	// Make a buffer to hold message
	buf := make([]byte, header.Length())
	// Read the incoming connection into the buffer.
	read, err := conn.Read(buf)
	if err != nil {
		// handle error
	}
	if reqLen != header.Length() {
		// handle error
	}

	message := iso8583.NewMessage(iso8583.Spec87)
	message.Unpack(buf)

	// work with the message
}
```

This is how you can write header into the net.Conn:

```go
header := network.NewBCD2BytesHeader()
packed, err := message.Pack()
if err != nil {
	// handle error
}
header.SetLength(len(packed))
_, err = header.WriteTo(conn)
if err != nil {
	// handle error
}
n, err := conn.Write(packed)
if err != nil {
	// handle error
}

```

Closes #70