### PR TITLE
FIX: serialize into JSON only fileds that were set

### DIFF
--- a/message.go
+++ b/message.go
@@ -212,7 +212,8 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	jsonData := field.OrderedMap(m.fields)
+	// get only filds that were set
+	jsonData := field.OrderedMap(m.GetFields())
 
 	return json.Marshal(jsonData)
 }
@@ -238,6 +239,9 @@ func (m *Message) setPackableDataFields() ([]int, error) {
 			if err := field.SetData(dataField.Interface()); err != nil {
 				return nil, fmt.Errorf("failed to set data for field %d: %w", id, err)
 			}
+
+			// mark field as set
+			m.fieldsMap[id] = struct{}{}
 		}
 
 		// These fields are set using the untyped API

--- a/message_test.go
+++ b/message_test.go
@@ -574,4 +574,17 @@ func TestMessageJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, want, string(got))
 	})
+
+	t.Run("Test JSON encoding untyped", func(t *testing.T) {
+		message := NewMessage(spec)
+		message.MTI("0100")
+		message.Field(2, "4242424242424242")
+		message.Field(4, "100")
+
+		want := `{"0":"0100","1":"500000000000000000000000000000000000000000000000","2":"4242424242424242","4":"100"}`
+
+		got, err := json.Marshal(message)
+		require.NoError(t, err)
+		require.Equal(t, want, string(got))
+	})
 }


### PR DESCRIPTION
I've found that we serialize into JSON all fields of the spec, while we need to serialize only fields that are set.

This PR also fixes the issue: setting data fields and packing does not mark fields as being set.