### PR TITLE
add Name to the MessageSpec

### DIFF
--- a/cmd/iso8583/describe/describe.go
+++ b/cmd/iso8583/describe/describe.go
@@ -13,7 +13,11 @@ import (
 )
 
 func Message(w io.Writer, message *iso8583.Message) error {
-	fmt.Fprintf(w, "ISO 8583 Message:\n")
+	specName := "ISO 8583"
+	if spec := message.GetSpec(); spec != nil && spec.Name != "" {
+		specName = spec.Name
+	}
+	fmt.Fprintf(w, "%s Message:\n", specName)
 
 	tw := tabwriter.NewWriter(w, 0, 0, 3, '.', 0)
 

--- a/message.go
+++ b/message.go
@@ -72,6 +72,10 @@ func (m *Message) MTI(val string) {
 	m.fields[0].SetBytes([]byte(val))
 }
 
+func (m *Message) GetSpec() *MessageSpec {
+	return m.spec
+}
+
 func (m *Message) Field(id int, val string) error {
 	if f, ok := m.fields[id]; ok {
 		m.fieldsMap[id] = struct{}{}

--- a/message_spec.go
+++ b/message_spec.go
@@ -7,6 +7,7 @@ import (
 )
 
 type MessageSpec struct {
+	Name   string
 	Fields map[int]field.Field
 }
 

--- a/spec87.go
+++ b/spec87.go
@@ -8,6 +8,7 @@ import (
 )
 
 var Spec87 *MessageSpec = &MessageSpec{
+	Name: "ISO 8583:1987 ASCII",
 	Fields: map[int]field.Field{
 		0: field.NewString(&field.Spec{
 			Length:      4,


### PR DESCRIPTION
With this PR we add `Name` field to the `MessageSpec`.

If there is a `Name` for the spec, in CLI it will be displayed as the intro message instead of generic `ISO 8583`:

```
ISO 8583:1987 ASCII Message:
MTI...............................................: 0800
Bitmap............................................: 7FFFFFFFFFFFFFFF
```

Closes #77 