### PR TITLE
try to describe message even if error on unpack

### DIFF
--- a/cmd/iso8583/describe.go
+++ b/cmd/iso8583/describe.go
@@ -22,7 +22,12 @@ func Describe(paths []string, specName string) error {
 	for _, path := range paths {
 		message, err := createMessageFromFile(path, spec)
 		if err != nil {
-			return fmt.Errorf("creating message from file: %w", err)
+			if message == nil {
+				return fmt.Errorf("creating message from file: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Failed to create message from file: %v\n", err)
+			fmt.Fprintf(os.Stdout, "Trying to describe file anyway...\n")
 		}
 
 		err = describe.Message(os.Stdout, message)
@@ -49,7 +54,7 @@ func createMessageFromFile(path string, spec *iso8583.MessageSpec) (*iso8583.Mes
 	message := iso8583.NewMessage(spec)
 	err = message.Unpack(raw)
 	if err != nil {
-		return nil, fmt.Errorf("unpacking ISO 8583 message: %v", err)
+		return message, fmt.Errorf("unpacking ISO 8583 message: %v", err)
 	}
 
 	return message, nil


### PR DESCRIPTION
In some cases like when spec describes more fields than message has, we still may benefit from seeing what's in the message.

With this PR we still will try to describe the message. Here is an example of such behaviour:

```
➜ so8583 describe -spec 87 message.dat
Failed to create message from file: unpacking ISO 8583 message: failed to unpack field 3 (Processing Code): failed to convert into number: strconv.Atoi: parsing "B00000": invalid syntax
Trying to describe file anyway...
ISO 8583 Message:
MTI....................: 3031
Bitmap.................: 3030F23C46D128E0
Bitmap bits............: 00110000 00110000 11110010 00111100 01000110 11010001 00101000 11100000
F003 Processing Code...: 0
``` 