### PR TITLE
Composite field: stop parsing bytes once length indicated by prefix is reached

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -141,7 +141,10 @@ func (f *Composite) Unpack(data []byte) (int, error) {
 	}
 	offset := f.spec.Pref.Length()
 
-	read, err := f.unpack(data[offset:])
+	// data is stripped of the prefix before it is provided to unpack().
+	// Therefore, it is unaware of when to stop parsing unless we bound the
+	// length of the slice by the data length.
+	read, err := f.unpack(data[offset : offset+dataLen])
 	if err != nil {
 		return 0, err
 	}

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -462,6 +462,26 @@ func TestCompositePackingWithID(t *testing.T) {
 		require.Nil(t, data.F2)
 		require.Equal(t, 12, data.F3.Value)
 	})
+
+	t.Run("Unpack correctly ignores excess bytes in excess of the length described by the prefix", func(t *testing.T) {
+		data := &CompsiteTestData{}
+
+		composite := NewComposite(compositeTestSpecWithIDLength)
+		err := composite.SetData(data)
+		require.NoError(t, err)
+
+		// "04060102YZ" falls outside of the bounds of the 18 byte limit imposed
+		// by the prefix. Therefore, F4 must be nil.
+		read, err := composite.Unpack([]byte("180202CD0302120102AB04060102YZ"))
+
+		require.NoError(t, err)
+		require.Equal(t, 20, read)
+
+		require.Equal(t, "AB", data.F1.Value)
+		require.Equal(t, "CD", data.F2.Value)
+		require.Equal(t, 12, data.F3.Value)
+		require.Nil(t, data.F4)
+	})
 }
 
 func TestCompositeHandlesValidSpecs(t *testing.T) {


### PR DESCRIPTION
Bug fix: If unpacking fields by ID, the composite field type currently does not stop parsing bytes when the length indicated by the prefix is reached.

This PR ensures that unpacking returns when that limit is reached.