### PR TITLE
Add binary field + tiny fixes

### DIFF
--- a/cmd/iso8583/describe/describe_test.go
+++ b/cmd/iso8583/describe/describe_test.go
@@ -1,0 +1,18 @@
+package describe
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/moov-io/iso8583"
+	"github.com/moov-io/iso8583/specs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribe(t *testing.T) {
+	message := iso8583.NewMessage(specs.Spec87ASCII)
+
+	require.NotPanics(t, func() {
+		Message(bytes.NewBuffer([]byte{}), message)
+	})
+}

--- a/field/binary.go
+++ b/field/binary.go
@@ -1,0 +1,113 @@
+package field
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var _ Field = (*Binary)(nil)
+
+type Binary struct {
+	Value []byte `json:"value"`
+	spec  *Spec
+	data  *Binary
+}
+
+func NewBinary(spec *Spec) *Binary {
+	return &Binary{
+		spec: spec,
+	}
+}
+
+func NewBinaryValue(val []byte) *Binary {
+	return &Binary{
+		Value: val,
+	}
+}
+
+func (f *Binary) Spec() *Spec {
+	return f.spec
+}
+
+func (f *Binary) SetSpec(spec *Spec) {
+	f.spec = spec
+}
+
+func (f *Binary) SetBytes(b []byte) error {
+	f.Value = b
+	return nil
+}
+
+func (f *Binary) Bytes() ([]byte, error) {
+	return f.Value, nil
+}
+
+func (f *Binary) String() (string, error) {
+	return fmt.Sprintf("%X", f.Value), nil
+}
+
+func (f *Binary) Pack() ([]byte, error) {
+	data := f.Value
+
+	if f.spec.Pad != nil {
+		data = f.spec.Pad.Pad(data, f.spec.Length)
+	}
+
+	packed, err := f.spec.Enc.Encode(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode content: %v", err)
+	}
+
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %v", err)
+	}
+
+	return append(packedLength, packed...), nil
+}
+
+func (f *Binary) Unpack(data []byte) (int, error) {
+	dataLen, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %v", err)
+	}
+
+	start := f.spec.Pref.Length()
+	raw, read, err := f.spec.Enc.Decode(data[start:], dataLen)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode content: %v", err)
+	}
+
+	if f.spec.Pad != nil {
+		raw = f.spec.Pad.Unpad(raw)
+	}
+
+	f.Value = raw
+
+	if f.data != nil {
+		*(f.data) = *f
+	}
+
+	return read + f.spec.Pref.Length(), nil
+}
+
+func (f *Binary) SetData(data interface{}) error {
+	if data == nil {
+		return nil
+	}
+
+	str, ok := data.(*Binary)
+	if !ok {
+		return fmt.Errorf("data does not match required *Binary type")
+	}
+
+	f.data = str
+	if str.Value != nil {
+		f.Value = str.Value
+	}
+	return nil
+}
+
+func (f *Binary) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.Value)
+}

--- a/field/binary_test.go
+++ b/field/binary_test.go
@@ -1,0 +1,72 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinaryField(t *testing.T) {
+	spec := &Spec{
+		Length:      10,
+		Description: "Field",
+		Enc:         encoding.Binary,
+		Pref:        prefix.Binary.Fixed,
+	}
+
+	in := []byte("1234567890")
+
+	t.Run("Pack returns binary data", func(t *testing.T) {
+		bin := NewBinary(spec)
+		bin.SetBytes(in)
+
+		packed, err := bin.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, in, packed)
+	})
+
+	t.Run("String returns binary data encoded in HEX", func(t *testing.T) {
+		bin := NewBinary(spec)
+		bin.Value = in
+
+		str, err := bin.String()
+
+		require.NoError(t, err)
+		require.Equal(t, "31323334353637383930", str)
+	})
+
+	t.Run("Unpack returns binary data", func(t *testing.T) {
+		bin := NewBinary(spec)
+
+		n, err := bin.Unpack(in)
+
+		require.NoError(t, err)
+		require.Equal(t, len(in), n)
+		require.Equal(t, in, bin.Value)
+	})
+
+	t.Run("SetData sets data to the field", func(t *testing.T) {
+		bin := NewBinary(spec)
+		bin.SetData(NewBinaryValue(in))
+
+		packed, err := bin.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, in, packed)
+	})
+
+	t.Run("Unpack sets data to data value", func(t *testing.T) {
+		bin := NewBinary(spec)
+		data := NewBinaryValue([]byte{})
+		bin.SetData(data)
+
+		n, err := bin.Unpack(in)
+
+		require.NoError(t, err)
+		require.Equal(t, len(in), n)
+		require.Equal(t, in, data.Value)
+	})
+}

--- a/message.go
+++ b/message.go
@@ -62,6 +62,7 @@ func (m *Message) Bitmap() *field.Bitmap {
 	}
 
 	m.bitmap = m.fields[1].(*field.Bitmap)
+	m.bitmap.Reset()
 	m.fieldsMap[1] = struct{}{}
 
 	return m.bitmap

--- a/specs/spec87ascii.go
+++ b/specs/spec87ascii.go
@@ -35,6 +35,7 @@ var Spec87ASCII *iso8583.MessageSpec = &iso8583.MessageSpec{
 			Description: "Processing Code",
 			Enc:         encoding.ASCII,
 			Pref:        prefix.ASCII.Fixed,
+			Pad:         padding.Left('0'),
 		}),
 		4: field.NewString(&field.Spec{
 			Length:      12,


### PR DESCRIPTION
This PR:

* adds `field.Binary` - to store binary data in []byte and display it HEX
* adds `0` padder to DE3 (Processing Code)
* fixes panics of `describe.Message` when it receives message with empty bitmpa (when no `Pack` or `Unpack` were called)