### PR TITLE
Add vmlh

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Following network headers are supported:
   bytes of the message
 * BCD2Bytes - message length encoded in 2 bytes BCD, e.g, {0x01, 0x15} for 115
   bytes of the message
+* VMLH (Visa Message Length Header) - message length encoded in 2 bytes + 2 reserved bytes
 
 You can read network header from the network connection like this:
 

--- a/network/vml_header.go
+++ b/network/vml_header.go
@@ -1,0 +1,75 @@
+package network
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/moov-io/iso8583/encoding"
+)
+
+const (
+	sessionControlIndicator = byte('2')
+	MaxMessageLength        = 2048
+)
+
+type VMLH struct {
+	Len uint16
+	//
+	IsSessionControl bool
+}
+
+func NewVMLHeader() *VMLH {
+	return &VMLH{}
+}
+
+func (h *VMLH) SetLength(length int) error {
+	if length > math.MaxUint16 {
+		return fmt.Errorf("length %d exceeds max length for 2 bytes header %d", length, math.MaxUint16)
+	}
+
+	h.Len = uint16(length)
+
+	return nil
+}
+
+func (h *VMLH) Length() int {
+	return int(h.Len)
+}
+
+func (h *VMLH) WriteTo(w io.Writer) (int, error) {
+	err := binary.Write(w, binary.BigEndian, h.Len)
+	if err != nil {
+		return 0, fmt.Errorf("wrigint uint16 into writer: %v", err)
+	}
+
+	return binary.Size(h.Len), nil
+}
+
+func (h *VMLH) ReadFrom(r io.Reader) (int, error) {
+	header := make([]byte, 4)
+
+	// read full header
+	read, err := io.ReadFull(r, header)
+	if err != nil {
+		return 0, fmt.Errorf("reading 4 bytes from reader: %v", err)
+	}
+
+	// read 2 bytes length
+	err = binary.Read(bytes.NewReader(header), binary.BigEndian, &h.Len)
+	if err != nil {
+		return 0, fmt.Errorf("reading uint16 length from reader: %v", err)
+	}
+
+	// read message format and platform
+	indicators, _, err := encoding.BCD.Decode(header[3:], 2)
+	if err != nil {
+		return 0, fmt.Errorf("decoding indicators: %v", err)
+	}
+
+	h.IsSessionControl = (indicators[0] == sessionControlIndicator)
+
+	return read, nil
+}

--- a/network/vml_header_test.go
+++ b/network/vml_header_test.go
@@ -8,21 +8,30 @@ import (
 )
 
 func TestVMLHeader(t *testing.T) {
-	// t.Run("Pack returns binary encoded length", func(t *testing.T) {
-	// 	header := NewBinary2BytesHeader()
+	t.Run("WriteTo writes binary encoded length into writer", func(t *testing.T) {
+		header := NewVMLHeader()
 
-	// 	header.SetLength(319)
-	// 	var buf bytes.Buffer
-	// 	n, err := header.WriteTo(&buf)
+		header.SetLength(15)
+		var buf bytes.Buffer
+		n, err := header.WriteTo(&buf)
 
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, 2, n)
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
 
-	// 	// len 319 encoded in bytes
-	// 	require.Equal(t, []byte{0x01, 0x3F}, buf.Bytes())
-	// })
+		// len 15 encoded in 2 bytes + reserved two bytes 0x00
+		require.Equal(t, []byte{0x00, 0x0F, 0x00, 0x00}, buf.Bytes())
+	})
 
-	t.Run("Read reads 4 bytes and decode length with session control", func(t *testing.T) {
+	t.Run("WriteTo returns error when message length exceeds max message length", func(t *testing.T) {
+		header := NewVMLHeader()
+		header.SetLength(MaxMessageLength + 1)
+
+		_, err := header.WriteTo(&bytes.Buffer{})
+
+		require.Error(t, err)
+	})
+
+	t.Run("ReadFrom reads 4 bytes and decode length with session control", func(t *testing.T) {
 		header := NewVMLHeader()
 
 		// Encoded:
@@ -42,11 +51,12 @@ func TestVMLHeader(t *testing.T) {
 		require.True(t, header.IsSessionControl)
 	})
 
-	t.Run("ReadFrom returns error when message length exceeds max message lenght", func(t *testing.T) {
-		// header := NewVMLHeader()
+	t.Run("ReadFrom returns error when message length exceeds max message length", func(t *testing.T) {
+		header := NewVMLHeader()
+		packed := []byte{0xFF, 0xFF, 0x00, 0x20}
+
+		_, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.Error(t, err)
 	})
-
-	// test
-	// 2048 - max message length
-
 }

--- a/network/vml_header_test.go
+++ b/network/vml_header_test.go
@@ -1,0 +1,52 @@
+package network
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVMLHeader(t *testing.T) {
+	// t.Run("Pack returns binary encoded length", func(t *testing.T) {
+	// 	header := NewBinary2BytesHeader()
+
+	// 	header.SetLength(319)
+	// 	var buf bytes.Buffer
+	// 	n, err := header.WriteTo(&buf)
+
+	// 	require.NoError(t, err)
+	// 	require.Equal(t, 2, n)
+
+	// 	// len 319 encoded in bytes
+	// 	require.Equal(t, []byte{0x01, 0x3F}, buf.Bytes())
+	// })
+
+	t.Run("Read reads 4 bytes and decode length with session control", func(t *testing.T) {
+		header := NewVMLHeader()
+
+		// Encoded:
+		// * 2 bytes len 15
+		// * one reserved byte
+		// * final byte:
+		//   - left nibble, optional for endpoint generated message, message format indicator: 2 - session control
+		//   - right nibble (platform indicator): 0 - direct member
+		// 000F0020
+		packed := []byte{0x00, 0x0F, 0x00, 0x20}
+		read, err := header.ReadFrom(bytes.NewReader(packed))
+
+		require.NoError(t, err)
+		require.Equal(t, 15, header.Length())
+		require.Equal(t, 4, read)
+
+		require.True(t, header.IsSessionControl)
+	})
+
+	t.Run("ReadFrom returns error when message length exceeds max message lenght", func(t *testing.T) {
+		// header := NewVMLHeader()
+	})
+
+	// test
+	// 2048 - max message length
+
+}


### PR DESCRIPTION
This PR:
* adds Visa Message Length Header - 2 bytes encoded length + 1 byte reserved + 1 byte (zero filled or contains Message format and Platform indicators)

Closes #105