### PR TITLE
Pack and read MTI using typed API

### DIFF
--- a/message.go
+++ b/message.go
@@ -256,8 +256,8 @@ func (m *Message) setPackableDataFields() ([]int, error) {
 
 		// These fields are set using the untyped API
 		_, ok := m.fieldsMap[id]
-                // We don't wish set the MTI again, hence we ignore the 0 
-                // index
+		// We don't wish set the MTI again, hence we ignore the 0
+		// index
 		if (ok || m.dataValue != nil) && id != 0 {
 			populatedFieldIDs = append(populatedFieldIDs, id)
 		}

--- a/message.go
+++ b/message.go
@@ -256,6 +256,8 @@ func (m *Message) setPackableDataFields() ([]int, error) {
 
 		// These fields are set using the untyped API
 		_, ok := m.fieldsMap[id]
+                // We don't wish set the MTI again, hence we ignore the 0 
+                // index
 		if (ok || m.dataValue != nil) && id != 0 {
 			populatedFieldIDs = append(populatedFieldIDs, id)
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -109,6 +109,7 @@ func TestMessage(t *testing.T) {
 		}
 
 		type ISO87Data struct {
+			F0 *field.String
 			F2 *field.String
 			F3 *TestISOF3Data
 			F4 *field.String
@@ -136,6 +137,7 @@ func TestMessage(t *testing.T) {
 
 		data := message.Data().(*ISO87Data)
 
+		require.Equal(t, "0100", data.F0.Value)
 		require.Equal(t, "4242424242424242", data.F2.Value)
 		require.Equal(t, "12", data.F3.F1.Value)
 		require.Equal(t, "34", data.F3.F2.Value)
@@ -151,14 +153,15 @@ func TestMessage(t *testing.T) {
 		}
 
 		type ISO87Data struct {
+			F0 *field.String
 			F2 *field.String
 			F3 *TestISOF3Data
 			F4 *field.String
 		}
 
 		message := NewMessage(spec)
-		message.MTI("0100")
 		err := message.SetData(&ISO87Data{
+			F0: field.NewStringValue("0100"),
 			F2: field.NewStringValue("4242424242424242"),
 			F3: &TestISOF3Data{
 				F1: field.NewStringValue("12"),


### PR DESCRIPTION
Currently, the MTI can neither be read nor set using the typed API. This PR implements behaviour to allow for that to happen.