### PR TITLE
Add support for configurable subfield sorting for composite fields

### DIFF
--- a/encoding/bertlv.go
+++ b/encoding/bertlv.go
@@ -26,8 +26,8 @@ func (berTLVEncoderTag) Encode(data []byte) ([]byte, error) {
 // 2) We must continue reading subsequent bytes until we arrive at one whose
 //    most significant bit is unset.
 //
-// On success, the ASCII representation of the Tag as well are returned along
-// with the number of bytes read e.g. []byte{0x5F, 0x2A} would be converted to
+// On success, the ASCII representation of the Tag is returned along with the
+// number of bytes read e.g. []byte{0x5F, 0x2A} would be converted to
 // []byte("5F2A")
 func (berTLVEncoderTag) Decode(data []byte, length int) ([]byte, int, error) {
 	r := bytes.NewReader(data)

--- a/field/composite.go
+++ b/field/composite.go
@@ -14,7 +14,7 @@ var _ Field = (*Composite)(nil)
 // Composite is a wrapper object designed to hold ISO8583 TLVs, subfields and
 // subelements. Because Composite handles both of these usecases generically,
 // we refer to them collectively as 'subfields' throughout the receiver's
-// documentation and error messages. These subfields are defined using the 
+// documentation and error messages. These subfields are defined using the
 // 'Subfields' field on the field.Spec struct.
 //
 // Composite handles aggregate fields of the following format:
@@ -317,9 +317,9 @@ func validateCompositeSpec(spec *Spec) error {
 	if spec.Tag != nil && spec.Tag.Enc == nil && spec.Tag.Length > 0 {
 		return fmt.Errorf("Composite spec requires a Tag.Enc to be defined if Tag.Length > 0")
 	}
-        if spec.Tag.Sort == nil {
-                return fmt.Errorf("Composite spec requires a Tag.Sort function to be defined")
-        }
+	if spec.Tag.Sort == nil {
+		return fmt.Errorf("Composite spec requires a Tag.Sort function to be defined")
+	}
 	return nil
 }
 
@@ -328,6 +328,6 @@ func orderedKeys(kvs map[string]Field, sorter sort.Strings) []string {
 	for k := range kvs {
 		keys = append(keys, k)
 	}
-        sorter(keys)
+	sorter(keys)
 	return keys
 }

--- a/field/composite.go
+++ b/field/composite.go
@@ -323,7 +323,7 @@ func validateCompositeSpec(spec *Spec) error {
 	return nil
 }
 
-func orderedKeys(kvs map[string]Field, sorter sort.Strings) []string {
+func orderedKeys(kvs map[string]Field, sorter sort.StringSlice) []string {
 	keys := make([]string, 0)
 	for k := range kvs {
 		keys = append(keys, k)

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -17,9 +17,9 @@ var (
 		Description: "Test Spec",
 		Pref:        prefix.ASCII.Fixed,
 		Pad:         padding.None,
-                Tag: &TagSpec{
-                        Sort: sort.StringsByInt,
-                },
+		Tag: &TagSpec{
+			Sort: sort.StringsByInt,
+		},
 		Subfields: map[string]Field{
 			"1": NewString(&Spec{
 				Length:      2,
@@ -49,7 +49,7 @@ var (
 			Length: 2,
 			Enc:    encoding.ASCII,
 			Pad:    padding.Left('0'),
-                        Sort: sort.StringsByInt,
+			Sort:   sort.StringsByInt,
 		},
 		Subfields: map[string]Field{
 			"1": NewString(&Spec{
@@ -78,7 +78,7 @@ var (
 					Length: 2,
 					Enc:    encoding.ASCII,
 					Pad:    padding.Left('0'),
-                                        Sort: sort.StringsByInt,
+					Sort:   sort.StringsByInt,
 				},
 				Subfields: map[string]Field{
 					"1": NewString(&Spec{
@@ -97,8 +97,8 @@ var (
 		Description: "ICC Data – EMV Having Multiple Tags",
 		Pref:        prefix.ASCII.LLL,
 		Tag: &TagSpec{
-			Enc: encoding.BerTLVTag,
-                        Sort: sort.StringsByHex,
+			Enc:  encoding.BerTLVTag,
+			Sort: sort.StringsByHex,
 		},
 		Subfields: map[string]Field{
 			"9A": NewString(&Spec{
@@ -116,9 +116,9 @@ var (
 )
 
 type CompsiteTestData struct {
-	F1 *String
-	F2 *String
-	F3 *Numeric
+	F1  *String
+	F2  *String
+	F3  *Numeric
 	F11 *SubCompositeData
 }
 
@@ -219,9 +219,9 @@ func TestCompositePacking(t *testing.T) {
 			// This will throw an error when encoding the field's length.
 			Length: 4,
 			Pref:   prefix.ASCII.Fixed,
-                        Tag: &TagSpec{
-                                Sort: sort.StringsByInt,
-                        },
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
 			Subfields: map[string]Field{
 				"1": NewString(&Spec{
 					Length: 2,
@@ -304,9 +304,9 @@ func TestCompositePacking(t *testing.T) {
 		spec := &Spec{
 			Length: 4,
 			Pref:   prefix.ASCII.L,
-                        Tag: &TagSpec{
-                                Sort: sort.StringsByInt,
-                        },
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
 			Subfields: map[string]Field{
 				"1": NewString(&Spec{
 					Length: 2,
@@ -344,9 +344,9 @@ func TestCompositePacking(t *testing.T) {
 			// This will throw an error when encoding the field's length.
 			Length: 4,
 			Pref:   prefix.ASCII.Fixed,
-                        Tag: &TagSpec{
-                                Sort: sort.StringsByInt,
-                        },
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
 			Subfields: map[string]Field{
 				"1": NewString(&Spec{
 					Length: 2,
@@ -407,7 +407,7 @@ func TestCompositePackingWithID(t *testing.T) {
 				Length: 2,
 				Enc:    encoding.ASCII,
 				Pad:    padding.Left('0'),
-                                Sort: sort.StringsByInt,
+				Sort:   sort.StringsByInt,
 			},
 			Subfields: map[string]Field{
 				"1": NewString(&Spec{
@@ -584,34 +584,34 @@ func TestCompositeHandlesValidSpecs(t *testing.T) {
 		{
 			desc: "accepts nil Enc value",
 			spec: &Spec{
-				Length:    6,
-				Pref:      prefix.ASCII.Fixed,
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
 				Tag: &TagSpec{
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]Field{},
 			},
 		},
 		{
 			desc: "accepts nil Pad value",
 			spec: &Spec{
-				Length:    6,
-				Pref:      prefix.ASCII.Fixed,
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
 				Tag: &TagSpec{
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]Field{},
 			},
 		},
 		{
 			desc: "accepts None Pad value",
 			spec: &Spec{
-				Length:    6,
-				Pref:      prefix.ASCII.Fixed,
-				Pad:       padding.None,
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Pad:    padding.None,
 				Tag: &TagSpec{
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]Field{},
 			},
 		},
@@ -654,7 +654,7 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 				Pref:      prefix.ASCII.Fixed,
 				Pad:       padding.Left('0'),
 				Subfields: map[string]Field{},
-				Tag: &TagSpec{},
+				Tag:       &TagSpec{},
 			},
 		},
 		{
@@ -666,8 +666,8 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 				Pad:       padding.Left('0'),
 				Subfields: map[string]Field{},
 				Tag: &TagSpec{
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort: sort.StringsByInt,
+				},
 			},
 		},
 		{
@@ -679,8 +679,8 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 				Pref:      prefix.ASCII.Fixed,
 				Subfields: map[string]Field{},
 				Tag: &TagSpec{
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort: sort.StringsByInt,
+				},
 			},
 		},
 		{
@@ -693,8 +693,8 @@ func TestCompositePanicsOnSpecValidationFailures(t *testing.T) {
 				Tag: &TagSpec{
 					Length: 2,
 					Pad:    padding.Left('0'),
-                                        Sort: sort.StringsByInt,
-                                },
+					Sort:   sort.StringsByInt,
+				},
 			},
 		},
 	}

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -153,8 +153,8 @@ type SubCompositeData struct {
 }
 
 type CompositeTestDataWithoutTagPadding struct {
-	F01  *String
-	F02  *String
+	F01 *String
+	F02 *String
 }
 
 type TLVTestData struct {

--- a/field/spec.go
+++ b/field/spec.go
@@ -30,7 +30,7 @@ type TagSpec struct {
 	// Sort defines the order in which Tags defined within the subfields
 	// spec must be packed. This ordering may also be used for unpacking
 	// if Spec.Tag.Enc == nil.
-	Sort sort.Strings
+	Sort sort.StringSlice
 }
 
 // Spec defines the structure of a field.

--- a/field/spec.go
+++ b/field/spec.go
@@ -27,10 +27,10 @@ type TagSpec struct {
 	// This is most commonly used for composite field types
 	// whose tags hold leading 0s e.g. '003' would be unpadded to '3'.
 	Pad padding.Padder
-        // Sort defines the order in which Tags defined within the subfields
-        // spec must be packed. This ordering may also be used for unpacking 
-        // if Spec.Tag.Enc == nil.
-        Sort sort.Strings
+	// Sort defines the order in which Tags defined within the subfields
+	// spec must be packed. This ordering may also be used for unpacking
+	// if Spec.Tag.Enc == nil.
+	Sort sort.Strings
 }
 
 // Spec defines the structure of a field.

--- a/field/spec.go
+++ b/field/spec.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moov-io/iso8583/encoding"
 	"github.com/moov-io/iso8583/padding"
 	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
 )
 
 // TagSpec is used to define the format of field tags (sometimes defined as field IDs).
@@ -26,6 +27,10 @@ type TagSpec struct {
 	// This is most commonly used for composite field types
 	// whose tags hold leading 0s e.g. '003' would be unpadded to '3'.
 	Pad padding.Padder
+        // Sort defines the order in which Tags defined within the subfields
+        // spec must be packed. This ordering may also be used for unpacking 
+        // if Spec.Tag.Enc == nil.
+        Sort sort.Strings
 }
 
 // Spec defines the structure of a field.

--- a/message_test.go
+++ b/message_test.go
@@ -369,7 +369,7 @@ func TestPackUnpack(t *testing.T) {
 				Description: "ICC Data – EMV Having Multiple Tags",
 				Pref:        prefix.ASCII.LLL,
 				Tag: &field.TagSpec{
-					Enc: encoding.BerTLVTag,
+					Enc:  encoding.BerTLVTag,
 					Sort: sort.StringsByHex,
 				},
 				Subfields: map[string]field.Field{

--- a/message_test.go
+++ b/message_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moov-io/iso8583/field"
 	"github.com/moov-io/iso8583/padding"
 	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,6 +37,9 @@ func TestMessage(t *testing.T) {
 				Length:      6,
 				Description: "Processing Code",
 				Pref:        prefix.ASCII.Fixed,
+				Tag: &field.TagSpec{
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]field.Field{
 					"1": field.NewString(&field.Spec{
 						Length:      2,
@@ -204,6 +208,9 @@ func TestPackUnpack(t *testing.T) {
 				Length:      6,
 				Description: "Processing Code",
 				Pref:        prefix.ASCII.Fixed,
+				Tag: &field.TagSpec{
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]field.Field{
 					"1": field.NewString(&field.Spec{
 						Length:      2,
@@ -363,6 +370,7 @@ func TestPackUnpack(t *testing.T) {
 				Pref:        prefix.ASCII.LLL,
 				Tag: &field.TagSpec{
 					Enc: encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
 				},
 				Subfields: map[string]field.Field{
 					"9A": field.NewString(&field.Spec{
@@ -548,6 +556,9 @@ func TestMessageJSON(t *testing.T) {
 				Length:      6,
 				Description: "Processing Code",
 				Pref:        prefix.ASCII.Fixed,
+				Tag: &field.TagSpec{
+					Sort: sort.StringsByInt,
+				},
 				Subfields: map[string]field.Field{
 					"1": field.NewString(&field.Spec{
 						Length:      2,

--- a/sort/strings.go
+++ b/sort/strings.go
@@ -11,7 +11,10 @@ import (
 
 // Strings is a function type used to sort a slice of strings in increasing
 // order. Any errors which arise from sorting the slice will raise a panic.
-type Strings func(x []string)
+type StringSlice func(x []string)
+
+// Strings sorts a slice of strings in increasing order.
+var Strings = sort.Strings
 
 // StringsByInt sorts a slice of strings according to their integer value.
 // This function panics in the event that an element in the slice cannot be

--- a/sort/strings.go
+++ b/sort/strings.go
@@ -1,8 +1,8 @@
 package sort
 
 import (
-        "fmt"
-        "math/big"
+	"fmt"
+	"math/big"
 	"sort"
 	"strconv"
 
@@ -13,22 +13,21 @@ import (
 // order. Any errors which arise from sorting the slice will raise a panic.
 type Strings func(x []string)
 
-
 // StringsByInt sorts a slice of strings according to their integer value.
 // This function panics in the event that an element in the slice cannot be
 // converted to an integer
 func StringsByInt(x []string) {
-        sort.Slice(x, func(i, j int) bool {
-                valI, err := strconv.Atoi(x[i])
-                if err != nil {
-                        panic("failed to sort strings by int: failed to convert string to int")
-                }
-                valJ, err := strconv.Atoi(x[j])
-                if err != nil {
-                        panic("failed to sort strings by int: failed to convert string to int")
-                }
-                return valI < valJ
-        })
+	sort.Slice(x, func(i, j int) bool {
+		valI, err := strconv.Atoi(x[i])
+		if err != nil {
+			panic("failed to sort strings by int: failed to convert string to int")
+		}
+		valJ, err := strconv.Atoi(x[j])
+		if err != nil {
+			panic("failed to sort strings by int: failed to convert string to int")
+		}
+		return valI < valJ
+	})
 }
 
 // StringsByHex sorts a slice of strings according to their big-endian Hex value.
@@ -36,15 +35,15 @@ func StringsByInt(x []string) {
 // converted to a Hex slice. Each string representation of a hex value must be
 // of even length.
 func StringsByHex(x []string) {
-        sort.Slice(x, func(i, j int) bool {
-                valI, err := encoding.ASCIIToHex.Encode([]byte(x[i]))
-                if err != nil {
-                        panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
-                }
-                valJ, err := encoding.ASCIIToHex.Encode([]byte(x[j]))
-                if err != nil {
-                        panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
-                }
-                return new(big.Int).SetBytes(valI).Int64() < new(big.Int).SetBytes(valJ).Int64()
-        })
+	sort.Slice(x, func(i, j int) bool {
+		valI, err := encoding.ASCIIToHex.Encode([]byte(x[i]))
+		if err != nil {
+			panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
+		}
+		valJ, err := encoding.ASCIIToHex.Encode([]byte(x[j]))
+		if err != nil {
+			panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
+		}
+		return new(big.Int).SetBytes(valI).Int64() < new(big.Int).SetBytes(valJ).Int64()
+	})
 }

--- a/sort/strings.go
+++ b/sort/strings.go
@@ -1,0 +1,50 @@
+package sort
+
+import (
+        "fmt"
+        "math/big"
+	"sort"
+	"strconv"
+
+	"github.com/moov-io/iso8583/encoding"
+)
+
+// Strings is a function type used to sort a slice of strings in increasing
+// order. Any errors which arise from sorting the slice will raise a panic.
+type Strings func(x []string)
+
+
+// StringsByInt sorts a slice of strings according to their integer value.
+// This function panics in the event that an element in the slice cannot be
+// converted to an integer
+func StringsByInt(x []string) {
+        sort.Slice(x, func(i, j int) bool {
+                valI, err := strconv.Atoi(x[i])
+                if err != nil {
+                        panic("failed to sort strings by int: failed to convert string to int")
+                }
+                valJ, err := strconv.Atoi(x[j])
+                if err != nil {
+                        panic("failed to sort strings by int: failed to convert string to int")
+                }
+                return valI < valJ
+        })
+}
+
+// StringsByHex sorts a slice of strings according to their big-endian Hex value.
+// This function panics in the event that an element in the slice cannot be
+// converted to a Hex slice. Each string representation of a hex value must be
+// of even length.
+func StringsByHex(x []string) {
+        sort.Slice(x, func(i, j int) bool {
+                valI, err := encoding.ASCIIToHex.Encode([]byte(x[i]))
+                if err != nil {
+                        panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
+                }
+                valJ, err := encoding.ASCIIToHex.Encode([]byte(x[j]))
+                if err != nil {
+                        panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
+                }
+                return new(big.Int).SetBytes(valI).Int64() < new(big.Int).SetBytes(valJ).Int64()
+        })
+}

--- a/sort/strings_test.go
+++ b/sort/strings_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestStringsByInt(t *testing.T) {
-        x := []string{"11", "5", "1"}
-        StringsByInt(x)
-        require.Equal(t, []string{"1", "5", "11"}, x)
+	x := []string{"11", "5", "1"}
+	StringsByInt(x)
+	require.Equal(t, []string{"1", "5", "11"}, x)
 }
 
 func TestStringsByHex(t *testing.T) {
-        x := []string{"B0", "10", "ABCD"}
-        StringsByHex(x)
-        require.Equal(t, []string{"10", "B0", "ABCD"}, x)
+	x := []string{"B0", "10", "ABCD"}
+	StringsByHex(x)
+	require.Equal(t, []string{"10", "B0", "ABCD"}, x)
 }

--- a/sort/strings_test.go
+++ b/sort/strings_test.go
@@ -6,13 +6,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringsByInt(t *testing.T) {
+func TestSortStrings(t *testing.T) {
+	x := []string{"1", "2", "11"}
+	Strings(x)
+	require.Equal(t, []string{"1", "11", "2"}, x)
+}
+
+func TestSortStringsByInt(t *testing.T) {
 	x := []string{"11", "5", "1"}
 	StringsByInt(x)
 	require.Equal(t, []string{"1", "5", "11"}, x)
 }
 
-func TestStringsByHex(t *testing.T) {
+func TestSortStringsByHex(t *testing.T) {
 	x := []string{"B0", "10", "ABCD"}
 	StringsByHex(x)
 	require.Equal(t, []string{"10", "B0", "ABCD"}, x)

--- a/sort/strings_test.go
+++ b/sort/strings_test.go
@@ -1,0 +1,19 @@
+package sort
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringsByInt(t *testing.T) {
+        x := []string{"11", "5", "1"}
+        StringsByInt(x)
+        require.Equal(t, []string{"1", "5", "11"}, x)
+}
+
+func TestStringsByHex(t *testing.T) {
+        x := []string{"B0", "10", "ABCD"}
+        StringsByHex(x)
+        require.Equal(t, []string{"10", "B0", "ABCD"}, x)
+}


### PR DESCRIPTION
Currently, the `Composite` field type performs basic but crude string sorting using the following function:

```
func orderedKeys(kvs map[string]Field) []string {
	keys := make([]string, 0)
	for k := range kvs {
		keys = append(keys, k)
	}
	sort.Strings(keys)
	return keys
}
```

This worked well before when we keyed subfields by `int`. However, our `subfields` now leverage `strings` to either key by `int` (for subfields and subelements) or `hex` (for TLVs). Relying on the function above alone means that calling `orderedKeys` on `[]string{"1", "2", "11"}` would mutate the slice to `[]string{"1", "11", "2"}`.

This PR introduces a new `sort` package with a `type StringSlice func(x []string)` function type.

This function type is referenced in the `TagSpec` struct defined in `field/spec.go` and is used to order subfields on initialisation of a `Composite` field type. In fact, the `Sort` parameter is now a required field in the `TagSpec` of a `Composite` field type. As such, this PR could be construed to be breaking because of this. I'll leave this detail up to the discretion of the reviewer