### PR TITLE
Implement JSON Unmarshaler interface on Message and Field types

### DIFF
--- a/field/binary.go
+++ b/field/binary.go
@@ -3,6 +3,7 @@ package field
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var _ Field = (*Binary)(nil)
@@ -115,5 +116,9 @@ func (f *Binary) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Binary) UnmarshalJSON(b []byte) error {
-	return f.SetBytes(b)
+	unqouted, err := strconv.Unquote(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to unquote input: %w", err)
+	}
+	return f.SetBytes([]byte(unqouted))
 }

--- a/field/binary.go
+++ b/field/binary.go
@@ -114,7 +114,5 @@ func (f *Binary) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Binary) UnmarshalJSON(b []byte) error {
-    var data map[string]json.RawMessage
-    json.Unmarshal(b, &data)
-    return nil
+	return f.SetBytes(b)
 }

--- a/field/binary.go
+++ b/field/binary.go
@@ -6,6 +6,8 @@ import (
 )
 
 var _ Field = (*Binary)(nil)
+var _ json.Marshaler = (*Binary)(nil)
+var _ json.Unmarshaler = (*Binary)(nil)
 
 type Binary struct {
 	Value []byte `json:"value"`
@@ -109,4 +111,10 @@ func (f *Binary) SetData(data interface{}) error {
 
 func (f *Binary) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Value)
+}
+
+func (f *Binary) UnmarshalJSON(b []byte) error {
+    var data map[string]json.RawMessage
+    json.Unmarshal(b, &data)
+    return nil
 }

--- a/field/binary_test.go
+++ b/field/binary_test.go
@@ -57,6 +57,17 @@ func TestBinaryField(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, in, packed)
 	})
+	
+	t.Run("SetBytes sets data to the data field", func(t *testing.T) {
+		bin := NewBinary(spec)
+		data := &Binary{}
+		bin.SetData(data)
+
+		err := bin.SetBytes(in)
+		require.NoError(t, err)
+
+		require.Equal(t, in, data.Value)
+	})
 
 	t.Run("Unpack sets data to data value", func(t *testing.T) {
 		bin := NewBinary(spec)

--- a/field/binary_test.go
+++ b/field/binary_test.go
@@ -57,7 +57,7 @@ func TestBinaryField(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, in, packed)
 	})
-	
+
 	t.Run("SetBytes sets data to the data field", func(t *testing.T) {
 		bin := NewBinary(spec)
 		data := &Binary{}

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -39,6 +39,9 @@ func (f *Bitmap) SetSpec(spec *Spec) {
 
 func (f *Bitmap) SetBytes(b []byte) error {
 	f.bitmap = utils.NewBitmapFromData(b)
+	if f.data != nil {
+		*(f.data) = *f
+	}
 	return nil
 }
 
@@ -101,10 +104,8 @@ func (f *Bitmap) Unpack(data []byte) (int, error) {
 		}
 	}
 
-	f.bitmap = utils.NewBitmapFromData(rawBitmap)
-
-	if f.data != nil {
-		*(f.data) = *f
+	if err := f.SetBytes(rawBitmap); err != nil {
+		return 0, fmt.Errorf("failed to set bytes: %w", err)
 	}
 
 	return read, nil

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -13,6 +13,8 @@ const minBitmapLength = 8 // 64 bit, 8 bytes, or 16 hex digits
 const maxBitmaps = 3
 
 var _ Field = (*Bitmap)(nil)
+var _ json.Marshaler = (*Bitmap)(nil)
+var _ json.Unmarshaler = (*Bitmap)(nil)
 
 type Bitmap struct {
 	spec   *Spec
@@ -185,4 +187,9 @@ func (f *Bitmap) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("failed to retrieve bytes: %v", err)
 	}
 	return json.Marshal(strings.ToUpper(hex.EncodeToString(data)))
+}
+
+// Takes in a HEX based string
+func (f *Bitmap) UnmarshalJSON(b []byte) error {
+	return f.SetBytes(b)
 }

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/moov-io/iso8583/utils"
 )
@@ -192,5 +193,9 @@ func (f *Bitmap) MarshalJSON() ([]byte, error) {
 
 // Takes in a HEX based string
 func (f *Bitmap) UnmarshalJSON(b []byte) error {
-	return f.SetBytes(b)
+	unqouted, err := strconv.Unquote(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to unquote input: %w", err)
+	}
+	return f.SetBytes([]byte(unqouted))
 }

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -4,8 +4,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/moov-io/iso8583/utils"
 )

--- a/field/bitmap_test.go
+++ b/field/bitmap_test.go
@@ -240,4 +240,18 @@ func TestBitmap_SetData(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, packed, 16) // 16 bytes is 8 bytes (one bitmap) encoded in hex
 	})
+
+	t.Run("SetBytes sets data to the data field", func(t *testing.T) {
+		bitmap := NewBitmap(spec)
+
+		data := &Bitmap{}
+		bitmap.SetData(data)
+
+		err := bitmap.SetBytes([]byte("a"))
+		require.NoError(t, err)
+		b, err := data.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, []byte("a"), b)
+	})
+
 }

--- a/field/composite.go
+++ b/field/composite.go
@@ -201,6 +201,9 @@ func (f *Composite) UnmarshalJSON(b []byte) error {
 		if !ok {
 			return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
 		}
+		if err := f.setSubfieldData(tag, subfield); err != nil {
+			return err
+		}
 		if err := json.Unmarshal(rawMsg, subfield); err != nil {
 			return fmt.Errorf("failed to unmarshal subfield %v: %w", tag, err)
 		}

--- a/field/composite.go
+++ b/field/composite.go
@@ -193,8 +193,8 @@ func (f *Composite) MarshalJSON() ([]byte, error) {
 // An error is thrown if the JSON consists of a subfield that has not
 // been defined in the spec.
 func (f *Composite) UnmarshalJSON(b []byte) error {
-    var data map[string]json.RawMessage
-    json.Unmarshal(b, &data)
+	var data map[string]json.RawMessage
+	json.Unmarshal(b, &data)
 
 	for tag, rawMsg := range data {
 		subfield, ok := f.tagToSubfieldMap[tag]
@@ -209,7 +209,7 @@ func (f *Composite) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-    return nil
+	return nil
 }
 
 func (f *Composite) pack() ([]byte, error) {

--- a/field/composite.go
+++ b/field/composite.go
@@ -10,6 +10,8 @@ import (
 )
 
 var _ Field = (*Composite)(nil)
+var _ json.Marshaler = (*Composite)(nil)
+var _ json.Unmarshaler = (*Composite)(nil)
 
 // Composite is a wrapper object designed to hold ISO8583 TLVs, subfields and
 // subelements. Because Composite handles both of these usecases generically,
@@ -185,6 +187,26 @@ func (f *Composite) String() (string, error) {
 func (f *Composite) MarshalJSON() ([]byte, error) {
 	jsonData := OrderedMap(f.tagToSubfieldMap)
 	return json.Marshal(jsonData)
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+// An error is thrown if the JSON consists of a subfield that has not
+// been defined in the spec.
+func (f *Composite) UnmarshalJSON(b []byte) error {
+    var data map[string]json.RawMessage
+    json.Unmarshal(b, &data)
+
+	for tag, rawMsg := range data {
+		subfield, ok := f.tagToSubfieldMap[tag]
+		if !ok {
+			return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
+		}
+		if err := json.Unmarshal(rawMsg, subfield); err != nil {
+			return fmt.Errorf("failed to unmarshal subfield %v: %w", tag, err)
+		}
+	}
+
+    return nil
 }
 
 func (f *Composite) pack() ([]byte, error) {

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -425,6 +425,22 @@ func TestCompositePacking(t *testing.T) {
 		require.Equal(t, 12, data.F3.Value)
 		require.Nil(t, data.F11)
 	})
+
+	t.Run("SetBytes correctly deserialises bytes to the data struct", func(t *testing.T) {
+		data := &CompositeTestData{}
+
+		composite := NewComposite(compositeTestSpec)
+		err := composite.SetData(data)
+		require.NoError(t, err)
+
+		err = composite.SetBytes([]byte("ABCD12"))
+		require.NoError(t, err)
+
+		require.Equal(t, "AB", data.F1.Value)
+		require.Equal(t, "CD", data.F2.Value)
+		require.Equal(t, 12, data.F3.Value)
+		require.Nil(t, data.F11)
+	})
 }
 
 func TestCompositePackingWithTags(t *testing.T) {

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -328,7 +328,7 @@ func TestCompositePacking(t *testing.T) {
 		read, err := composite.Unpack([]byte("ABCDEF"))
 		require.Equal(t, 0, read)
 		require.Error(t, err)
-		require.EqualError(t, err, "failed to unpack subfield 3: failed to convert into number: strconv.Atoi: parsing \"EF\": invalid syntax")
+		require.EqualError(t, err, "failed to unpack subfield 3: failed to set bytes: failed to convert into number: strconv.Atoi: parsing \"EF\": invalid syntax")
 	})
 
 	t.Run("Unpack returns an error on length of data exceeding max length", func(t *testing.T) {

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -130,5 +130,9 @@ func (f *Numeric) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Numeric) UnmarshalJSON(b []byte) error {
-	return f.SetBytes(b)
+	unqouted, err := strconv.Unquote(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to unquote input: %w", err)
+	}
+	return f.SetBytes([]byte(unqouted))
 }

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -7,6 +7,8 @@ import (
 )
 
 var _ Field = (*Numeric)(nil)
+var _ json.Marshaler = (*Numeric)(nil)
+var _ json.Unmarshaler = (*Numeric)(nil)
 
 type Numeric struct {
 	Value int `json:"value"`
@@ -125,4 +127,8 @@ func (f *Numeric) SetData(data interface{}) error {
 
 func (f *Numeric) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Value)
+}
+
+func (f *Numeric) UnmarshalJSON(b []byte) error {
+	return f.SetBytes(b)
 }

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -37,11 +37,24 @@ func (f *Numeric) SetSpec(spec *Spec) {
 }
 
 func (f *Numeric) SetBytes(b []byte) error {
-	val, err := strconv.Atoi(string(b))
-	if err == nil {
+	if len(b) == 0 {
+		// for a length 0 raw, string(raw) would become "" which makes Atoi return an error
+		// however for example "0000" (value 0 left-padded with '0') should have 0 as output, not an error
+		// so if the length of raw is 0, set f.Value to 0 instead of parsing the raw
+		f.Value = 0
+	} else {
+		// otherwise parse the raw to an int
+		val, err := strconv.Atoi(string(b))
+		if err != nil {
+			return fmt.Errorf("failed to convert into number: %w", err)
+		}
 		f.Value = val
 	}
-	return err
+
+	if f.data != nil {
+		*(f.data) = *f
+	}
+	return nil
 }
 
 func (f *Numeric) Bytes() ([]byte, error) {
@@ -61,12 +74,12 @@ func (f *Numeric) Pack() ([]byte, error) {
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode length: %v", err)
+		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
 
 	return append(packedLength, packed...), nil
@@ -76,33 +89,20 @@ func (f *Numeric) Pack() ([]byte, error) {
 func (f *Numeric) Unpack(data []byte) (int, error) {
 	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
+		return 0, fmt.Errorf("failed to decode content: %w", err)
 	}
 
 	if f.spec.Pad != nil {
 		raw = f.spec.Pad.Unpad(raw)
 	}
 
-	if len(raw) == 0 {
-		// for a length 0 raw, string(raw) would become "" which makes Atoi return an error
-		// however for example "0000" (value 0 left-padded with '0') should have 0 as output, not an error
-		// so if the length of raw is 0, set f.Value to 0 instead of parsing the raw
-		f.Value = 0
-	} else {
-		// otherwise parse the raw to an int
-		f.Value, err = strconv.Atoi(string(raw))
-		if err != nil {
-			return 0, fmt.Errorf("failed to convert into number: %v", err)
-		}
-	}
-
-	if f.data != nil {
-		*(f.data) = *f
+	if err := f.SetBytes(raw); err != nil {
+		return 0, fmt.Errorf("failed to set bytes: %w", err)
 	}
 
 	return read + prefBytes, nil

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -102,3 +102,21 @@ func TestNumericFieldZeroLeftPaddedZero(t *testing.T) {
 
 	require.Equal(t, 0, numeric.Value)
 }
+
+func TestNumericSetBytesSetsDataOntoDataStruct(t *testing.T) {
+	numeric := NewNumeric(&Spec{
+		Length:      1,
+		Description: "Field",
+		Enc:         encoding.ASCII,
+		Pref:        prefix.ASCII.Fixed,
+	})
+
+	data := &Numeric{}
+	err := numeric.SetData(data)
+	require.NoError(t, err)
+
+	err = numeric.SetBytes([]byte("9"))
+	require.NoError(t, err)
+
+	require.Equal(t, 9, data.Value)
+}

--- a/field/spec.go
+++ b/field/spec.go
@@ -48,8 +48,7 @@ type Spec struct {
 	// binary etc
 	Enc encoding.Encoder
 	// Pref defines the prefixer of the field used to encode and decode the
-	// length of the field. Only applicable to primitive field types e.g.
-	// numerics, strings, binary etc
+	// length of the field.
 	Pref prefix.Prefixer
 	// Pad sets the padding direction and type of the field.
 	Pad padding.Padder

--- a/field/string.go
+++ b/field/string.go
@@ -3,6 +3,7 @@ package field
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 var _ Field = (*String)(nil)
@@ -115,5 +116,9 @@ func (f *String) MarshalJSON() ([]byte, error) {
 }
 
 func (f *String) UnmarshalJSON(b []byte) error {
-	return f.SetBytes(b)
+	unqouted, err := strconv.Unquote(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to unquote input: %w", err)
+	}
+	return f.SetBytes([]byte(unqouted))
 }

--- a/field/string.go
+++ b/field/string.go
@@ -6,6 +6,8 @@ import (
 )
 
 var _ Field = (*String)(nil)
+var _ json.Marshaler = (*String)(nil)
+var _ json.Unmarshaler = (*String)(nil)
 
 type String struct {
 	Value string `json:"value"`
@@ -109,4 +111,8 @@ func (f *String) SetData(data interface{}) error {
 
 func (f *String) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Value)
+}
+
+func (f *String) UnmarshalJSON(b []byte) error {
+	return f.SetBytes(b)
 }

--- a/field/string.go
+++ b/field/string.go
@@ -37,6 +37,9 @@ func (f *String) SetSpec(spec *Spec) {
 
 func (f *String) SetBytes(b []byte) error {
 	f.Value = string(b)
+	if f.data != nil {
+		*(f.data) = *f
+	}
 	return nil
 }
 
@@ -57,12 +60,12 @@ func (f *String) Pack() ([]byte, error) {
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode length: %v", err)
+		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
 
 	return append(packedLength, packed...), nil
@@ -71,22 +74,20 @@ func (f *String) Pack() ([]byte, error) {
 func (f *String) Unpack(data []byte) (int, error) {
 	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
+		return 0, fmt.Errorf("failed to decode content: %w", err)
 	}
 
 	if f.spec.Pad != nil {
 		raw = f.spec.Pad.Unpad(raw)
 	}
 
-	f.Value = string(raw)
-
-	if f.data != nil {
-		*(f.data) = *f
+	if err := f.SetBytes(raw); err != nil {
+		return 0, fmt.Errorf("failed to set bytes: %w", err)
 	}
 
 	return read + prefBytes, nil

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -49,4 +49,11 @@ func TestStringField(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 10, length)
 	require.Equal(t, "olleh", data.Value)
+
+	str = NewString(spec)
+	data = &String{}
+	str.SetData(data)
+	err = str.SetBytes([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", data.Value)
 }

--- a/message.go
+++ b/message.go
@@ -237,8 +237,8 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 }
 
 func (m *Message) UnmarshalJSON(b []byte) error {
-    var data map[string]json.RawMessage
-    json.Unmarshal(b, &data)
+	var data map[string]json.RawMessage
+	json.Unmarshal(b, &data)
 
 	for id, rawMsg := range data {
 		i, err := strconv.Atoi(id)
@@ -263,7 +263,7 @@ func (m *Message) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-    return nil
+	return nil
 }
 
 func (m *Message) setPackableDataFields() ([]int, error) {

--- a/message_test.go
+++ b/message_test.go
@@ -597,15 +597,16 @@ func TestMessageJSON(t *testing.T) {
 	}
 
 	type TestISOData struct {
+		F0 *field.String
 		F2 *field.String
 		F3 *TestISOF3Data
 		F4 *field.String
 	}
 
-	t.Run("Test JSON encoding", func(t *testing.T) {
+	t.Run("Test JSON encoding typed", func(t *testing.T) {
 		message := NewMessage(spec)
-		message.MTI("0100")
 		err := message.SetData(&TestISOData{
+			F0: field.NewStringValue("0100"),
 			F2: field.NewStringValue("4242424242424242"),
 			F3: &TestISOF3Data{
 				F1: field.NewStringValue("12"),
@@ -635,4 +636,42 @@ func TestMessageJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, want, string(got))
 	})
+
+	t.Run("Test JSON decoding typed", func(t *testing.T) {
+		message := NewMessage(spec)
+
+		input := `{"0":"0100","1":"700000000000000000000000000000000000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
+
+		data := &TestISOData{}
+		err := message.SetData(data)
+		require.NoError(t, err)
+
+		want := &TestISOData{
+			F0: field.NewStringValue("0100"),
+			F2: field.NewStringValue("4242424242424242"),
+			F3: &TestISOF3Data{
+				F1: field.NewStringValue("12"),
+				F2: field.NewStringValue("34"),
+				F3: field.NewStringValue("56"),
+			},
+			F4: field.NewStringValue("100"),
+		}
+
+		err = json.Unmarshal([]byte(input), message)
+		require.NoError(t, err)
+		require.Equal(t, want, data)
+	})
+
+	// t.Run("Test JSON encoding untyped", func(t *testing.T) {
+	// 	message := NewMessage(spec)
+	// 	message.MTI("0100")
+	// 	message.Field(2, "4242424242424242")
+	// 	message.Field(4, "100")
+
+	// 	want := `{"0":"0100","1":"500000000000000000000000000000000000000000000000","2":"4242424242424242","4":"100"}`
+
+	// 	got, err := json.Marshal(message)
+	// 	require.NoError(t, err)
+	// 	require.Equal(t, want, string(got))
+	// })
 }

--- a/message_test.go
+++ b/message_test.go
@@ -659,19 +659,32 @@ func TestMessageJSON(t *testing.T) {
 
 		err = json.Unmarshal([]byte(input), message)
 		require.NoError(t, err)
-		require.Equal(t, want, data)
+		require.Equal(t, want.F0.Value, data.F0.Value)
+		require.Equal(t, want.F2.Value, data.F2.Value)
+		require.Equal(t, want.F3.F1.Value, data.F3.F1.Value)
+		require.Equal(t, want.F3.F2.Value, data.F3.F2.Value)
+		require.Equal(t, want.F3.F3.Value, data.F3.F3.Value)
+		require.Equal(t, want.F4.Value, data.F4.Value)
 	})
 
-	// t.Run("Test JSON encoding untyped", func(t *testing.T) {
-	// 	message := NewMessage(spec)
-	// 	message.MTI("0100")
-	// 	message.Field(2, "4242424242424242")
-	// 	message.Field(4, "100")
+	t.Run("Test JSON encoding untyped", func(t *testing.T) {
+		message := NewMessage(spec)
 
-	// 	want := `{"0":"0100","1":"500000000000000000000000000000000000000000000000","2":"4242424242424242","4":"100"}`
+		input := `{"0":"0100","1":"500000000000000000000000000000000000000000000000","2":"4242424242424242","4":"100"}`
 
-	// 	got, err := json.Marshal(message)
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, want, string(got))
-	// })
+		err := json.Unmarshal([]byte(input), message)
+		require.NoError(t, err)
+
+		mti, err := message.GetMTI()
+		require.NoError(t, err)
+		require.Equal(t, "0100", mti)
+
+		f2, err := message.GetString(2)
+		require.NoError(t, err)
+		require.Equal(t, "4242424242424242", f2)
+
+		f4, err := message.GetString(4)
+		require.NoError(t, err)
+		require.Equal(t, "100", f4)
+	})
 }


### PR DESCRIPTION
# New Behaviour

As of this PR, users may now unmarshal JSON back into an `*iso8583.Message` object using the untyped API as such:

```
input := `{"0":"0100","1":"500000000000000000000000000000000000000000000000","2":"4242424242424242","4":"100"}`

message := NewMessage(spec)
if err := json.Unmarshal([]byte(input), message); err != nil {
    // handle err
}
```

Similarly, the typed API may be used as such:

```
input := `{"0":"0100","1":"700000000000000000000000000000000000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`

message := NewMessage(spec)
data := &TestISOData{}
if err := message.SetData(data); err != nil {
    // handle error
}
if err = json.Unmarshal([]byte(input), message); err != nil {
    // handle err
}

fmt.Printf("Field F2: %v", data.F2.Value) // This will print "4242424242424242"
```

This allows for some powerful behaviour to be built on top of the library e.g. Building JSON APIs which then convert messages into ISO8583 to then process for test purposes.

I've also improved some of the error handling and the implementation of `SetBytes()` to set the value of the data struct if one exists along the way.