### PR TITLE
Support 'D' separator in Track 2

### DIFF
--- a/field/spec.go
+++ b/field/spec.go
@@ -52,9 +52,6 @@ type Spec struct {
 	Pref prefix.Prefixer
 	// Pad sets the padding direction and type of the field.
 	Pad padding.Padder
-	// Separator defines the character used to encode the separator. Only
-	// applicable to the Track 2 field type.
-	Separator string
 	// Subfields defines the subfields held within the field. Only
 	// applicable to composite field types.
 	Subfields map[string]Field


### PR DESCRIPTION
This PR adds support for parsing Track 2 data which uses `D` as a separator, and then packing this data with the chosen separator.

This change is necessary since the MasterCard documentation defines the separator character as `D`, while tolerating the usage of `=` as many devices perform non-standard character translation. Therefore, we change the parsing to consider both `D` or `=` as the separator character.

