### PR TITLE
Fix BCD decoding to limit number of bytes being read from source

### DIFF
--- a/encoding/bcd.go
+++ b/encoding/bcd.go
@@ -35,7 +35,7 @@ func (e *bcdEncoder) Decode(src []byte, length int) ([]byte, int, error) {
 
 	dec := bcd.NewDecoder(bcd.Standard)
 	dst := make([]byte, decodedLen)
-	_, err := dec.Decode(dst, src)
+	_, err := dec.Decode(dst, src[:read])
 	if err != nil {
 		return nil, 0, err
 	}

--- a/encoding/bcd_test.go
+++ b/encoding/bcd_test.go
@@ -25,6 +25,18 @@ func TestBCD(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []byte("230"), res)
 		require.Equal(t, 2, read)
+
+		res, read, err = BCD.Decode([]byte{0x21, 0x43, 0x55}, 4)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("2143"), res)
+		require.Equal(t, 2, read)
+
+		res, read, err = BCD.Decode([]byte{0x21, 0x43, 0xff}, 4)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("2143"), res)
+		require.Equal(t, 2, read)
 	})
 
 	t.Run("Encode", func(t *testing.T) {


### PR DESCRIPTION
- BCD Decoding was failing if the next Data Element is not encoded in non BCD format (i.e. EBCDIC).
- This PR limits the source byte array provided to BCD Decoder
The comment [here](https://github.com/yerden/go-util/issues/2#issuecomment-943418272) provided the hint. Thanks.