### PR TITLE
Fix error wrapping

### DIFF
--- a/cmd/iso8583/describe.go
+++ b/cmd/iso8583/describe.go
@@ -56,19 +56,19 @@ func DescribeWithSpecFile(paths []string, specFileName string) error {
 func createMessageFromFile(path string, spec *iso8583.MessageSpec) (*iso8583.Message, error) {
 	fd, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %s: %v", path, err)
+		return nil, fmt.Errorf("opening file %s: %w", path, err)
 	}
 	defer fd.Close()
 
 	raw, err := ioutil.ReadAll(fd)
 	if err != nil {
-		return nil, fmt.Errorf("reading file %s: %v", path, err)
+		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}
 
 	message := iso8583.NewMessage(spec)
 	err = message.Unpack(raw)
 	if err != nil {
-		return message, fmt.Errorf("unpacking message: %v", err)
+		return message, fmt.Errorf("unpacking message: %w", err)
 	}
 
 	return message, nil
@@ -77,13 +77,13 @@ func createMessageFromFile(path string, spec *iso8583.MessageSpec) (*iso8583.Mes
 func createSpecFromFile(path string) (*iso8583.MessageSpec, error) {
 	fd, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %s: %v", path, err)
+		return nil, fmt.Errorf("opening file %s: %w", path, err)
 	}
 	defer fd.Close()
 
 	raw, err := ioutil.ReadAll(fd)
 	if err != nil {
-		return nil, fmt.Errorf("reading file %s: %v", path, err)
+		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}
 
 	return specs.Builder.ImportJSON(raw)

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -62,14 +62,14 @@ func (f *Bitmap) Pack() ([]byte, error) {
 	// here we have max possible bytes for the bitmap 8*maxBitmaps
 	data, err := f.Bytes()
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve bytes: %v", err)
+		return nil, fmt.Errorf("failed to retrieve bytes: %w", err)
 	}
 
 	data = data[0 : 8*count]
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	return packed, nil
@@ -82,7 +82,7 @@ func (f *Bitmap) Pack() ([]byte, error) {
 func (f *Bitmap) Unpack(data []byte) (int, error) {
 	minLen, _, err := f.spec.Pref.DecodeLength(minBitmapLength, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	rawBitmap := make([]byte, 0)
@@ -92,7 +92,7 @@ func (f *Bitmap) Unpack(data []byte) (int, error) {
 	for i := 0; i < maxBitmaps; i++ {
 		decoded, readDecoded, err := f.spec.Enc.Decode(data[read:], minLen)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode content for %d bitmap: %v", i+1, err)
+			return 0, fmt.Errorf("failed to decode content for %d bitmap: %w", i+1, err)
 		}
 		read += readDecoded
 
@@ -186,7 +186,7 @@ func (f *Bitmap) setBitmapFields() bool {
 func (f *Bitmap) MarshalJSON() ([]byte, error) {
 	data, err := f.Bytes()
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve bytes: %v", err)
+		return nil, fmt.Errorf("failed to retrieve bytes: %w", err)
 	}
 	return json.Marshal(strings.ToUpper(hex.EncodeToString(data)))
 }

--- a/field/composite.go
+++ b/field/composite.go
@@ -246,7 +246,7 @@ func (f *Composite) pack() ([]byte, error) {
 
 		packedBytes, err := specField.Pack()
 		if err != nil {
-			return nil, fmt.Errorf("failed to pack subfield %v: %v", tag, err)
+			return nil, fmt.Errorf("failed to pack subfield %v: %w", tag, err)
 		}
 		packed = append(packed, packedBytes...)
 	}
@@ -269,7 +269,7 @@ func (f *Composite) unpackSubfields(data []byte) (int, error) {
 		}
 		read, err := specField.Unpack(data[offset:])
 		if err != nil {
-			return 0, fmt.Errorf("failed to unpack subfield %v: %v", tag, err)
+			return 0, fmt.Errorf("failed to unpack subfield %v: %w", tag, err)
 		}
 		offset += read
 	}

--- a/field/track1.go
+++ b/field/track1.go
@@ -57,7 +57,7 @@ func (f *Track1) Bytes() ([]byte, error) {
 func (f *Track1) String() (string, error) {
 	b, err := f.pack()
 	if err != nil {
-		return "", fmt.Errorf("failed to encode string: %v", err)
+		return "", fmt.Errorf("failed to encode string: %w", err)
 	}
 	return string(b), nil
 }
@@ -74,12 +74,12 @@ func (f *Track1) Pack() ([]byte, error) {
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode length: %v", err)
+		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
 
 	return append(packedLength, packed...), nil
@@ -89,12 +89,12 @@ func (f *Track1) Pack() ([]byte, error) {
 func (f *Track1) Unpack(data []byte) (int, error) {
 	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
+		return 0, fmt.Errorf("failed to decode content: %w", err)
 	}
 
 	if f.spec.Pad != nil {

--- a/field/track2.go
+++ b/field/track2.go
@@ -53,7 +53,7 @@ func (f *Track2) Bytes() ([]byte, error) {
 func (f *Track2) String() (string, error) {
 	b, err := f.pack()
 	if err != nil {
-		return "", fmt.Errorf("failed to encode string: %v", err)
+		return "", fmt.Errorf("failed to encode string: %w", err)
 	}
 	return string(b), nil
 }
@@ -70,12 +70,12 @@ func (f *Track2) Pack() ([]byte, error) {
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode length: %v", err)
+		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
 
 	return append(packedLength, packed...), nil
@@ -85,12 +85,12 @@ func (f *Track2) Pack() ([]byte, error) {
 func (f *Track2) Unpack(data []byte) (int, error) {
 	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
+		return 0, fmt.Errorf("failed to decode content: %w", err)
 	}
 
 	if f.spec.Pad != nil {

--- a/field/track3.go
+++ b/field/track3.go
@@ -54,7 +54,7 @@ func (f *Track3) Bytes() ([]byte, error) {
 func (f *Track3) String() (string, error) {
 	b, err := f.pack()
 	if err != nil {
-		return "", fmt.Errorf("failed to encode string: %v", err)
+		return "", fmt.Errorf("failed to encode string: %w", err)
 	}
 	return string(b), nil
 }
@@ -71,12 +71,12 @@ func (f *Track3) Pack() ([]byte, error) {
 
 	packed, err := f.spec.Enc.Encode(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode content: %v", err)
+		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
 	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode length: %v", err)
+		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
 
 	return append(packedLength, packed...), nil
@@ -86,12 +86,12 @@ func (f *Track3) Pack() ([]byte, error) {
 func (f *Track3) Unpack(data []byte) (int, error) {
 	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode length: %v", err)
+		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
 	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %v", err)
+		return 0, fmt.Errorf("failed to decode content: %w", err)
 	}
 
 	if f.spec.Pad != nil {

--- a/network/ascii_4bytes_header.go
+++ b/network/ascii_4bytes_header.go
@@ -33,7 +33,7 @@ func (h *ASCII4BytesHeader) ReadFrom(r io.Reader) (int, error) {
 	buf := make([]byte, 4)
 	read, err := io.ReadFull(r, buf)
 	if err != nil {
-		return 0, fmt.Errorf("reading header: %v", err)
+		return 0, fmt.Errorf("reading header: %w", err)
 	}
 
 	if read != 4 {
@@ -42,7 +42,7 @@ func (h *ASCII4BytesHeader) ReadFrom(r io.Reader) (int, error) {
 
 	l, err := strconv.Atoi(string(buf))
 	if err != nil {
-		return 0, fmt.Errorf("converting header to int: %v", err)
+		return 0, fmt.Errorf("converting header to int: %w", err)
 	}
 	h.Len = l
 

--- a/network/bcd_2bytes.go
+++ b/network/bcd_2bytes.go
@@ -40,7 +40,7 @@ func (h *BCD2BytesHeader) ReadFrom(r io.Reader) (int, error) {
 	buf := make([]byte, 2)
 	read, err := io.ReadFull(r, buf)
 	if err != nil {
-		return 0, fmt.Errorf("reading header: %v", err)
+		return 0, fmt.Errorf("reading header: %w", err)
 	}
 
 	// decode 4 digits from the buf
@@ -51,7 +51,7 @@ func (h *BCD2BytesHeader) ReadFrom(r io.Reader) (int, error) {
 
 	dataLen, err := strconv.Atoi(string(bDigits))
 	if err != nil {
-		return 0, fmt.Errorf("converting string to int: %v", err)
+		return 0, fmt.Errorf("converting string to int: %w", err)
 	}
 
 	h.Len = dataLen

--- a/network/binary_2bytes.go
+++ b/network/binary_2bytes.go
@@ -32,7 +32,7 @@ func (h *Binary2Bytes) Length() int {
 func (h *Binary2Bytes) WriteTo(w io.Writer) (int, error) {
 	err := binary.Write(w, binary.BigEndian, h.Len)
 	if err != nil {
-		return 0, fmt.Errorf("wrigint uint16 into writer: %v", err)
+		return 0, fmt.Errorf("wrigint uint16 into writer: %w", err)
 	}
 
 	return binary.Size(h.Len), nil
@@ -41,7 +41,7 @@ func (h *Binary2Bytes) WriteTo(w io.Writer) (int, error) {
 func (h *Binary2Bytes) ReadFrom(r io.Reader) (int, error) {
 	err := binary.Read(r, binary.BigEndian, &h.Len)
 	if err != nil {
-		return 0, fmt.Errorf("reading uint16 from reader: %v", err)
+		return 0, fmt.Errorf("reading uint16 from reader: %w", err)
 	}
 
 	return binary.Size(h.Len), nil

--- a/network/vml_header.go
+++ b/network/vml_header.go
@@ -51,17 +51,17 @@ func (h *VMLH) WriteTo(w io.Writer) (int, error) {
 
 	err := binary.Write(&buf, binary.BigEndian, h.Len)
 	if err != nil {
-		return 0, fmt.Errorf("wrigint uint16 into writer: %v", err)
+		return 0, fmt.Errorf("wrigint uint16 into writer: %w", err)
 	}
 
 	_, err = buf.Write([]byte{0x00, 0x00})
 	if err != nil {
-		return 0, fmt.Errorf("writing reserved bytes: %v", err)
+		return 0, fmt.Errorf("writing reserved bytes: %w", err)
 	}
 
 	n, err := w.Write(buf.Bytes())
 	if err != nil {
-		return 0, fmt.Errorf("writing header: %v", err)
+		return 0, fmt.Errorf("writing header: %w", err)
 	}
 
 	return n, nil
@@ -73,13 +73,13 @@ func (h *VMLH) ReadFrom(r io.Reader) (int, error) {
 	// read full header
 	read, err := io.ReadFull(r, header)
 	if err != nil {
-		return 0, fmt.Errorf("reading 4 bytes from reader: %v", err)
+		return 0, fmt.Errorf("reading 4 bytes from reader: %w", err)
 	}
 
 	// read 2 bytes length
 	err = binary.Read(bytes.NewReader(header), binary.BigEndian, &h.Len)
 	if err != nil {
-		return 0, fmt.Errorf("reading uint16 length from reader: %v", err)
+		return 0, fmt.Errorf("reading uint16 length from reader: %w", err)
 	}
 
 	if h.Len > MaxMessageLength {
@@ -89,7 +89,7 @@ func (h *VMLH) ReadFrom(r io.Reader) (int, error) {
 	// read message format and platform
 	indicators, _, err := encoding.BCD.Decode(header[3:], 2)
 	if err != nil {
-		return 0, fmt.Errorf("decoding indicators: %v", err)
+		return 0, fmt.Errorf("decoding indicators: %w", err)
 	}
 
 	h.IsSessionControl = (indicators[0] == sessionControlIndicator)

--- a/specs/builder.go
+++ b/specs/builder.go
@@ -187,7 +187,7 @@ func (builder *messageSpecBuilder) ImportJSON(raw []byte) (*iso8583.MessageSpec,
 	dummySpec := specDummy{}
 	err := json.Unmarshal(raw, &dummySpec)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshaling spec: %v", err)
+		return nil, fmt.Errorf("unmarshalling spec: %w", err)
 	}
 
 	if len(dummySpec.Fields) == 0 {
@@ -355,7 +355,7 @@ func (om orderedFieldMap) MarshalJSON() ([]byte, error) {
 	for k := range om {
 		index, err := strconv.Atoi(k)
 		if err != nil {
-			return nil, fmt.Errorf("convering field index into int: %v", err)
+			return nil, fmt.Errorf("converting field index into int: %w", err)
 		}
 		keys = append(keys, index)
 	}

--- a/test/fuzz-reader/reader.go
+++ b/test/fuzz-reader/reader.go
@@ -40,7 +40,7 @@ func Fuzz(data []byte) int {
 
 	_, err = message.Pack()
 	if err != nil {
-		panic(fmt.Errorf("failed to pack unpacked message: %v", err))
+		panic(fmt.Errorf("failed to pack unpacked message: %w", err))
 	}
 
 	return 1


### PR DESCRIPTION
The PR fixes an issue with the error wrapping in different places across the repository. 
%w should be used as otherwise errors can't be properly unwrapped when using functions
such as error.As().