### PR TITLE
Use index field tag for iso8583.Unmarshal

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -56,19 +56,28 @@ func Unmarshal(message *Message, v interface{}) error {
 	return nil
 }
 
-var indexFieldNameRe = regexp.MustCompile(`^F\d+$`)
+var fieldNameIndexRe = regexp.MustCompile(`^F\d+$`)
 
 // fieldIndex returns index of the field. First, it checks field name. If it
-// does not match FNN (when NN is digits), it checks value of `index` tag.
-// If negative value returned (-1) then index was not found for the field.
+// does not match FNN (when NN is digits), it checks value of `index` tag.  If
+// negative value returned (-1) then index was not found for the field.
 func getFieldIndex(field reflect.StructField) (int, error) {
 	dataFieldName := field.Name
 
-	if len(dataFieldName) > 0 && indexFieldNameRe.MatchString(dataFieldName) {
+	if len(dataFieldName) > 0 && fieldNameIndexRe.MatchString(dataFieldName) {
 		indexStr := dataFieldName[1:]
 		fieldIndex, err := strconv.Atoi(indexStr)
 		if err != nil {
-			return -1, fmt.Errorf("converting field intex into int: %w", err)
+			return -1, fmt.Errorf("converting field index into int: %w", err)
+		}
+
+		return fieldIndex, nil
+	}
+
+	if indexStr := field.Tag.Get("index"); indexStr != "" {
+		fieldIndex, err := strconv.Atoi(indexStr)
+		if err != nil {
+			return -1, fmt.Errorf("converting field index into int: %w", err)
 		}
 
 		return fieldIndex, nil

--- a/decode.go
+++ b/decode.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 )
 
@@ -25,17 +26,14 @@ func Unmarshal(message *Message, v interface{}) error {
 
 	// iterate over struct fields
 	for i := 0; i < dataStruct.NumField(); i++ {
-		dataFieldName := dataStruct.Type().Field(i).Name
-
-		// skip struct field if its name starts not from F
-		if len(dataFieldName) == 0 || dataFieldName[0:1] != "F" {
-			continue
+		fieldIndex, err := getFieldIndex(dataStruct.Type().Field(i))
+		if err != nil {
+			return fmt.Errorf("getting field %d index: %w", i, err)
 		}
 
-		indexStr := dataFieldName[1:]
-		fieldIndex, err := strconv.Atoi(indexStr)
-		if err != nil {
-			return fmt.Errorf("converting field intex into int: %w", err)
+		// skip field without index
+		if fieldIndex < 0 {
+			continue
 		}
 
 		// we can get data only if field value is set
@@ -56,4 +54,25 @@ func Unmarshal(message *Message, v interface{}) error {
 	}
 
 	return nil
+}
+
+var indexFieldNameRe = regexp.MustCompile(`^F\d+$`)
+
+// fieldIndex returns index of the field. First, it checks field name. If it
+// does not match FNN (when NN is digits), it checks value of `index` tag.
+// If negative value returned (-1) then index was not found for the field.
+func getFieldIndex(field reflect.StructField) (int, error) {
+	dataFieldName := field.Name
+
+	if len(dataFieldName) > 0 && indexFieldNameRe.MatchString(dataFieldName) {
+		indexStr := dataFieldName[1:]
+		fieldIndex, err := strconv.Atoi(indexStr)
+		if err != nil {
+			return -1, fmt.Errorf("converting field intex into int: %w", err)
+		}
+
+		return fieldIndex, nil
+	}
+
+	return -1, nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,7 @@
 package iso8583
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/moov-io/iso8583/encoding"
@@ -11,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecode(t *testing.T) {
+func TestUnmarshal(t *testing.T) {
 	spec := &MessageSpec{
 		Fields: map[int]field.Field{
 			0: field.NewString(&field.Spec{
@@ -114,22 +115,20 @@ func TestDecode(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("Unmarshal should not panic when field names no not follow FNN pattern", func(t *testing.T) {
+	t.Run("Unmarshal using field tags", func(t *testing.T) {
 		type TestISOF3Data struct {
-			A  string
-			F  string
-			F1 *field.String
-			F2 *field.String
-			F3 *field.String
+			One   *field.String `index:"1"`
+			Two   *field.String `index:"2"`
+			Three *field.String `index:"3"`
 		}
 
 		type ISO87Data struct {
-			F0   *field.String
-			F2   *field.String
-			F3   *TestISOF3Data
-			F4   *field.String
-			Name *field.String
+			MTI                  *field.String  `index:"0"`
+			PrimaryAccountNumber *field.String  `index:"2"`
+			AdditionalData       *TestISOF3Data `index:"3"`
+			Amount               *field.String  `index:"4"`
 		}
+
 		message := NewMessage(spec)
 
 		rawMsg := []byte("01007000000000000000164242424242424242123456000000000100")
@@ -137,40 +136,75 @@ func TestDecode(t *testing.T) {
 
 		require.NoError(t, err)
 
-		err = Unmarshal(message, &ISO87Data{})
+		data := &ISO87Data{}
+		err = Unmarshal(message, data)
 		require.NoError(t, err)
+
+		require.Equal(t, "0100", data.MTI.Value)
+		require.Equal(t, "4242424242424242", data.PrimaryAccountNumber.Value)
+		require.Equal(t, "12", data.AdditionalData.One.Value)
+		require.Equal(t, "34", data.AdditionalData.Two.Value)
+		require.Equal(t, "56", data.AdditionalData.Three.Value)
+		require.Equal(t, "100", data.Amount.Value)
+	})
+}
+
+func TestUnmarshal_getFieldIndex(t *testing.T) {
+	t.Run("returns index from field name", func(t *testing.T) {
+		st := reflect.ValueOf(&struct {
+			F1 string
+		}{}).Elem()
+
+		index, err := getFieldIndex(st.Type().Field(0))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, index)
 	})
 
-	// t.Run("Unmarshal using field tags", func(t *testing.T) {
-	// 	type TestISOF3Data struct {
-	// 		One   *field.String `index:"1"`
-	// 		Two   *field.String `index:"2"`
-	// 		Three *field.String `index:"3"`
-	// 	}
+	t.Run("returns index from field tag", func(t *testing.T) {
+		st := reflect.ValueOf(&struct {
+			Name   string `index:"abcd"`
+			F      string `index:"02"`
+			Amount string `index:"3"`
+		}{}).Elem()
 
-	// 	type ISO87Data struct {
-	// 		MTI                  *field.String  `index:"0"`
-	// 		PrimaryAccountNumber *field.String  `index:"2"`
-	// 		AdditionalData       *TestISOF3Data `index:"3"`
-	// 		Amount               *field.String  `index:"4"`
-	// 	}
+		// get index from field Name
+		_, err := getFieldIndex(st.Type().Field(0))
 
-	// 	message := NewMessage(spec)
+		require.Error(t, err)
+		require.EqualError(t, err, "converting field index into int: strconv.Atoi: parsing \"abcd\": invalid syntax")
 
-	// 	rawMsg := []byte("01007000000000000000164242424242424242123456000000000100")
-	// 	err := message.Unpack([]byte(rawMsg))
+		// get index from field F
+		index, err := getFieldIndex(st.Type().Field(1))
 
-	// 	require.NoError(t, err)
+		require.NoError(t, err)
+		require.Equal(t, 2, index)
 
-	// 	data := &ISO87Data{}
-	// 	err = Unmarshal(message, data)
-	// 	require.NoError(t, err)
+		// get index from field Amount
+		index, err = getFieldIndex(st.Type().Field(2))
 
-	// 	require.Equal(t, "0100", data.MTI.Value)
-	// 	require.Equal(t, "4242424242424242", data.PrimaryAccountNumber.Value)
-	// 	require.Equal(t, "12", data.AdditionalData.One.Value)
-	// 	require.Equal(t, "34", data.AdditionalData.Two.Value)
-	// 	require.Equal(t, "56", data.AdditionalData.Three.Value)
-	// 	require.Equal(t, "100", data.Amount.Value)
-	// })
+		require.NoError(t, err)
+		require.Equal(t, 3, index)
+	})
+
+	t.Run("returns empty string when no tag and field name does not match the pattern", func(t *testing.T) {
+		st := reflect.ValueOf(&struct {
+			Name string
+		}{}).Elem()
+
+		index, err := getFieldIndex(st.Type().Field(0))
+
+		require.NoError(t, err)
+		require.Equal(t, -1, index)
+
+		// single letter field without tag is ignored
+		st = reflect.ValueOf(&struct {
+			F string
+		}{}).Elem()
+
+		index, err = getFieldIndex(st.Type().Field(0))
+
+		require.NoError(t, err)
+		require.Equal(t, -1, index)
+	})
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -140,4 +140,37 @@ func TestDecode(t *testing.T) {
 		err = Unmarshal(message, &ISO87Data{})
 		require.NoError(t, err)
 	})
+
+	// t.Run("Unmarshal using field tags", func(t *testing.T) {
+	// 	type TestISOF3Data struct {
+	// 		One   *field.String `index:"1"`
+	// 		Two   *field.String `index:"2"`
+	// 		Three *field.String `index:"3"`
+	// 	}
+
+	// 	type ISO87Data struct {
+	// 		MTI                  *field.String  `index:"0"`
+	// 		PrimaryAccountNumber *field.String  `index:"2"`
+	// 		AdditionalData       *TestISOF3Data `index:"3"`
+	// 		Amount               *field.String  `index:"4"`
+	// 	}
+
+	// 	message := NewMessage(spec)
+
+	// 	rawMsg := []byte("01007000000000000000164242424242424242123456000000000100")
+	// 	err := message.Unpack([]byte(rawMsg))
+
+	// 	require.NoError(t, err)
+
+	// 	data := &ISO87Data{}
+	// 	err = Unmarshal(message, data)
+	// 	require.NoError(t, err)
+
+	// 	require.Equal(t, "0100", data.MTI.Value)
+	// 	require.Equal(t, "4242424242424242", data.PrimaryAccountNumber.Value)
+	// 	require.Equal(t, "12", data.AdditionalData.One.Value)
+	// 	require.Equal(t, "34", data.AdditionalData.Two.Value)
+	// 	require.Equal(t, "56", data.AdditionalData.Three.Value)
+	// 	require.Equal(t, "100", data.Amount.Value)
+	// })
 }


### PR DESCRIPTION
This PR allows us to use struct fields with tags instead of naming fields like F1, F22.  **It's a backward compatible change.**

**Example**:
```go
type ISO87Data struct {
	MTI                  *field.String  `index:"0"`
	PrimaryAccountNumber *field.String  `index:"2"`
	Amount               *field.String  `index:"3"`
}

message := iso8583.NewMessage(spec)

err := message.Unpack(...)
// handle error


data := &ISO87Data{}
err = Unmarshal(message, data)

data.MTI.Value // => "0100"
data.PrimaryAccountNumber.Value // => "4242424242424242", 
data.Amount.Value // => "100"

```

This is a partial solution of the https://github.com/moov-io/iso8583/issues/160

Please note, that implemented feature in the PR supports field tags only for `iso8583.Unmarshal`. The current implementation of `message.SetData` does not allow us to implement the same functionality in a simple way.

As a next step, we will introduce `iso8583.Marshal` which will support struct fields with tags as well.