### PR TITLE
let Marshal accept value (not only pointer)

### DIFF
--- a/message.go
+++ b/message.go
@@ -295,15 +295,17 @@ func (m *Message) Clone() (*Message, error) {
 
 // Marshal populates message fields with v struct field values. It traverses
 // through the message fields and calls Unmarshal(...) on them setting the v If
-// v  is nil or not a pointer it returns error.
+// v is not a struct or not a pointer to struct then it returns error.
 func (m *Message) Marshal(v interface{}) error {
-	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
-		return errors.New("data is not a pointer or nil")
+	if v == nil {
+		return nil
 	}
 
-	// get the struct from the pointer
-	dataStruct := rv.Elem()
+	dataStruct := reflect.ValueOf(v)
+
+	if dataStruct.Kind() == reflect.Ptr || dataStruct.Kind() == reflect.Interface {
+		dataStruct = dataStruct.Elem()
+	}
 
 	if dataStruct.Kind() != reflect.Struct {
 		return errors.New("data is not a struct")

--- a/message_test.go
+++ b/message_test.go
@@ -1305,7 +1305,7 @@ func TestMessageMarshaling(t *testing.T) {
 		require.Equal(t, "100", data.F4.Value)
 	})
 
-	t.Run("Marshal nil", func(t *testing.T) {
+	t.Run("Marshal nil returns nil", func(t *testing.T) {
 		message := NewMessage(spec)
 
 		rawMsg := []byte("01007000000000000000164242424242424242123456000000000100")
@@ -1314,7 +1314,7 @@ func TestMessageMarshaling(t *testing.T) {
 		require.NoError(t, err)
 
 		err = message.Marshal(nil)
-		require.Error(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Marshal using field tags", func(t *testing.T) {


### PR DESCRIPTION
**What:**
* `message.Marshal(data)` accept struct as arg in addition to a pointer to struct. Such behavior was in the `SetData` method before and it was pretty handy.

**Why:**
Switching to `Marshal` from `SetData` will be painless if we support the same behavior by accepting both struct and pointer to struct.