### PR TITLE
use index tag first, field name second

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -476,12 +476,12 @@ var fieldNameTagRe = regexp.MustCompile(`^F.+$`)
 func getFieldIndexOrTag(field reflect.StructField) (string, error) {
 	dataFieldName := field.Name
 
-	if len(dataFieldName) > 0 && fieldNameTagRe.MatchString(dataFieldName) {
-		return dataFieldName[1:], nil
-	}
-
 	if fieldIndex := field.Tag.Get("index"); fieldIndex != "" {
 		return fieldIndex, nil
+	}
+
+	if len(dataFieldName) > 0 && fieldNameTagRe.MatchString(dataFieldName) {
+		return dataFieldName[1:], nil
 	}
 
 	return "", nil

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -1051,6 +1051,17 @@ func TestComposite_getFieldIndexOrTag(t *testing.T) {
 		require.Equal(t, "1", index)
 	})
 
+	t.Run("returns index from field tag instead of field name when both match", func(t *testing.T) {
+		st := reflect.ValueOf(&struct {
+			F1 string `index:"AB"`
+		}{}).Elem()
+
+		index, err := getFieldIndexOrTag(st.Type().Field(0))
+
+		require.NoError(t, err)
+		require.Equal(t, "AB", index)
+	})
+
 	t.Run("returns index from field tag", func(t *testing.T) {
 		st := reflect.ValueOf(&struct {
 			Name string `index:"abcd"`

--- a/message.go
+++ b/message.go
@@ -406,8 +406,7 @@ var fieldNameIndexRe = regexp.MustCompile(`^F\d+$`)
 func getFieldIndex(field reflect.StructField) (int, error) {
 	dataFieldName := field.Name
 
-	if len(dataFieldName) > 0 && fieldNameIndexRe.MatchString(dataFieldName) {
-		indexStr := dataFieldName[1:]
+	if indexStr := field.Tag.Get("index"); indexStr != "" {
 		fieldIndex, err := strconv.Atoi(indexStr)
 		if err != nil {
 			return -1, fmt.Errorf("converting field index into int: %w", err)
@@ -416,7 +415,8 @@ func getFieldIndex(field reflect.StructField) (int, error) {
 		return fieldIndex, nil
 	}
 
-	if indexStr := field.Tag.Get("index"); indexStr != "" {
+	if len(dataFieldName) > 0 && fieldNameIndexRe.MatchString(dataFieldName) {
+		indexStr := dataFieldName[1:]
 		fieldIndex, err := strconv.Atoi(indexStr)
 		if err != nil {
 			return -1, fmt.Errorf("converting field index into int: %w", err)

--- a/message_test.go
+++ b/message_test.go
@@ -1161,6 +1161,17 @@ func Test_getFieldIndex(t *testing.T) {
 		require.Equal(t, 1, index)
 	})
 
+	t.Run("returns index from field tag instead of field name when both match", func(t *testing.T) {
+		st := reflect.ValueOf(&struct {
+			F1 string `index:"2"`
+		}{}).Elem()
+
+		index, err := getFieldIndex(st.Type().Field(0))
+
+		require.NoError(t, err)
+		require.Equal(t, 2, index)
+	})
+
 	t.Run("returns index from field tag", func(t *testing.T) {
 		st := reflect.ValueOf(&struct {
 			Name   string `index:"abcd"`


### PR DESCRIPTION
When we marshal/unmarshal field values, we match struct fields by name first and by `index` tag second. When we check the field name we use [regexp](https://github.com/moov-io/iso8583/blob/master/message.go#L401): `^F\d+$` (field name starts with `F` and has digits after it). Because composite fields can have tag names that are not digits, we only check that field starts with `F` with [the regexp](https://github.com/moov-io/iso8583/blob/master/message.go#L401): `^F.+$`.

So, if you marshal/unmarshal composite field that starts with `F` and also has index, then the index tag will be ignored. Imagine you have tag `01` and a struct:

```go
type OriginalElements struct {
        ForwadingInsitutionCode *field.String `index:"01"`
}
```

Guess what? You will spend time trying to understand why tag `01` is not set when you marhsal/unmarshal data. And it's because the composite field will take `orwadingInsitutionCode` as an index of the field and will try to find a spec for such field.

To avoid such cases, we are changing the field name matching priorities by checking the `index` tag first and the field name second.

**Technically, it can be a breaking change if you use `index` tag on the struct for something else.**