### PR TITLE
Exporting CreateFromJsonFile Method

### DIFF
--- a/cmd/iso8583/describe.go
+++ b/cmd/iso8583/describe.go
@@ -44,7 +44,7 @@ func Describe(paths []string, specName string) error {
 }
 
 func DescribeWithSpecFile(paths []string, specFileName string) error {
-	spec, err := createSpecFromFile(specFileName)
+	spec, err := specs.CreateFromJsonFile(specFileName)
 	if err != nil || spec == nil {
 		return fmt.Errorf("creating spec from file: %w", err)
 	}
@@ -71,19 +71,4 @@ func createMessageFromFile(path string, spec *iso8583.MessageSpec) (*iso8583.Mes
 	}
 
 	return message, nil
-}
-
-func createSpecFromFile(path string) (*iso8583.MessageSpec, error) {
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening file %s: %w", path, err)
-	}
-	defer fd.Close()
-
-	raw, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return nil, fmt.Errorf("reading file %s: %w", path, err)
-	}
-
-	return specs.Builder.ImportJSON(raw)
 }

--- a/specs/specs.go
+++ b/specs/specs.go
@@ -1,0 +1,25 @@
+package specs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/moov-io/iso8583"
+)
+
+// CreateFromJsonFile returns a MessageSpec generated from the input file
+func CreateFromJsonFile(path string) (*iso8583.MessageSpec, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %s: %w", path, err)
+	}
+	defer fd.Close()
+
+	raw, err := ioutil.ReadAll(fd)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %s: %w", path, err)
+	}
+
+	return Builder.ImportJSON(raw)
+}


### PR DESCRIPTION
I need -as an user of the library-, to generate the message specification from a Json file.

Thus, moving a little bit the code it could be possible with just importing the `specs` package, so that I would call:

`specs.CreateFromJsonFile(...)`

Which sintactically makes sense, since the specification is created from the json file.

This method was used  (and only) by the /cmd/iso8583 folder, but since this one is calling the `specs` package I decided that the best was to move into this last one to avoid a cyclic dependency.

Hopefully makes sense

@adamdecaf 

resolve #183 