### PR TITLE
Wrap errors from external libraries to prevent leaking sensitive information

### DIFF
--- a/encoding/ascii.go
+++ b/encoding/ascii.go
@@ -2,6 +2,8 @@ package encoding
 
 import (
 	"fmt"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 var ASCII Encoder = &asciiEncoder{}
@@ -12,7 +14,7 @@ func (e asciiEncoder) Encode(data []byte) ([]byte, error) {
 	var out []byte
 	for _, r := range data {
 		if r > 127 {
-			return nil, fmt.Errorf("invalid ASCII char: '%s'", string(r))
+			return nil, utils.NewSafeError(fmt.Errorf("invalid ASCII char: '%s'", string(r)), "failed to perform ASCII encoding")
 		}
 		out = append(out, r)
 	}
@@ -29,7 +31,7 @@ func (e asciiEncoder) Decode(data []byte, length int) ([]byte, int, error) {
 	var out []byte
 	for _, r := range data {
 		if r > 127 {
-			return nil, 0, fmt.Errorf("invalid ASCII char: '%s'", string(r))
+			return nil, 0, utils.NewSafeError(fmt.Errorf("invalid ASCII char: '%s'", string(r)), "failed to perform ASCII decoding")
 		}
 		out = append(out, r)
 	}

--- a/encoding/ascii_test.go
+++ b/encoding/ascii_test.go
@@ -18,6 +18,7 @@ func TestASCII(t *testing.T) {
 
 		_, _, err = enc.Decode([]byte("hello, 世界!"), 10)
 		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform ASCII decoding")
 
 		_, _, err = enc.Decode([]byte("hello"), 6)
 		require.Error(t, err)
@@ -36,5 +37,6 @@ func TestASCII(t *testing.T) {
 
 		_, err = enc.Encode([]byte("hello, 世界!"))
 		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform ASCII encoding")
 	})
 }

--- a/encoding/bcd.go
+++ b/encoding/bcd.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"fmt"
 
+	"github.com/moov-io/iso8583/utils"
 	"github.com/yerden/go-util/bcd"
 )
 
@@ -19,7 +20,7 @@ func (e *bcdEncoder) Encode(src []byte) ([]byte, error) {
 	dst := make([]byte, bcd.EncodedLen(len(src)))
 	n, err := enc.Encode(dst, src)
 	if err != nil {
-		return nil, err
+		return nil, utils.NewSafeError(err, "failed to perform BCD encoding")
 	}
 
 	return dst[:n], nil
@@ -43,7 +44,7 @@ func (e *bcdEncoder) Decode(src []byte, length int) ([]byte, int, error) {
 	dst := make([]byte, decodedLen)
 	_, err := dec.Decode(dst, src[:read])
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, utils.NewSafeError(err, "failed to perform BCD decoding")
 	}
 
 	// becase BCD is right aligned, we skip first bytes and

--- a/encoding/bcd_test.go
+++ b/encoding/bcd_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yerden/go-util/bcd"
 )
 
 func TestBCD(t *testing.T) {
@@ -45,18 +46,26 @@ func TestBCD(t *testing.T) {
 		_, _, err = BCD.Decode(nil, 6)
 		require.Error(t, err)
 		require.EqualError(t, err, "not enough data to decode. expected len 3, got 0")
+
+		_, _, err = BCD.Decode([]byte{0xAB, 0xCD}, 4)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD decoding")
+		require.ErrorIs(t, err, bcd.ErrBadBCD)
 	})
 
 	t.Run("Encode", func(t *testing.T) {
 		res, err := BCD.Encode([]byte("0110"))
-
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x01, 0x10}, res)
 
 		// right justified by default
 		res, err = BCD.Encode([]byte("123"))
-
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x01, 0x23}, res)
+
+		_, err = BCD.Encode([]byte("abc"))
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD encoding")
+		require.ErrorIs(t, err, bcd.ErrBadInput)
 	})
 }

--- a/encoding/bertlv.go
+++ b/encoding/bertlv.go
@@ -2,8 +2,9 @@ package encoding
 
 import (
 	"bytes"
-	"fmt"
 	"math/bits"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 // BER-TLV Tag encoder
@@ -34,7 +35,7 @@ func (berTLVEncoderTag) Decode(data []byte, length int) ([]byte, int, error) {
 
 	firstByte, err := r.ReadByte()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, utils.NewSafeError(err, "failed to read byte")
 	}
 	tagLenBytes := 1
 
@@ -46,7 +47,7 @@ func (berTLVEncoderTag) Decode(data []byte, length int) ([]byte, int, error) {
 	for shouldReadSubsequentByte {
 		b, err := r.ReadByte()
 		if err != nil {
-			return nil, tagLenBytes, fmt.Errorf("failed to decode TLV tag: %w", err)
+			return nil, tagLenBytes, utils.NewSafeError(err, "failed to decode TLV tag")
 		}
 		tagLenBytes++
 		// We read subsequent bytes to extract the tag by checking if

--- a/encoding/bertlv_test.go
+++ b/encoding/bertlv_test.go
@@ -42,6 +42,18 @@ func TestBerTLVTag(t *testing.T) {
 }
 
 func TestBerTLVTag_DecodeOnInvalidInput(t *testing.T) {
+	t.Run("when bytes are nil", func(t *testing.T) {
+		_, _, err := BerTLVTag.Decode(nil, 0)
+		require.EqualError(t, err, "failed to read byte")
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("when bytes are empty", func(t *testing.T) {
+		_, _, err := BerTLVTag.Decode([]byte{}, 0)
+		require.EqualError(t, err, "failed to read byte")
+		require.ErrorIs(t, err, io.EOF)
+	})
+
 	t.Run("when bits 5-1 of first byte set but 2nd byte does not exist", func(t *testing.T) {
 		_, _, err := BerTLVTag.Decode([]byte{0x5F}, 0)
 		require.EqualError(t, err, "failed to decode TLV tag")

--- a/encoding/bertlv_test.go
+++ b/encoding/bertlv_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,11 +44,13 @@ func TestBerTLVTag(t *testing.T) {
 func TestBerTLVTag_DecodeOnInvalidInput(t *testing.T) {
 	t.Run("when bits 5-1 of first byte set but 2nd byte does not exist", func(t *testing.T) {
 		_, _, err := BerTLVTag.Decode([]byte{0x5F}, 0)
-		require.EqualError(t, err, "failed to decode TLV tag: EOF")
+		require.EqualError(t, err, "failed to decode TLV tag")
+		require.ErrorIs(t, err, io.EOF)
 	})
 
 	t.Run("when MSB of 2nd byte set but 3nd byte does not exist", func(t *testing.T) {
 		_, _, err := BerTLVTag.Decode([]byte{0x5F, 0xA8}, 0)
-		require.EqualError(t, err, "failed to decode TLV tag: EOF")
+		require.EqualError(t, err, "failed to decode TLV tag")
+		require.ErrorIs(t, err, io.EOF)
 	})
 }

--- a/encoding/hex.go
+++ b/encoding/hex.go
@@ -2,8 +2,10 @@ package encoding
 
 import (
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"strings"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 // HEX to ASCII encoder
@@ -31,14 +33,14 @@ func (e hexToASCIIEncoder) Decode(data []byte, length int) ([]byte, int, error) 
 	// to read 8 HEX digits we have to read 16 ASCII chars (bytes)
 	read := hex.EncodedLen(length)
 	if read > len(data) {
-		return nil, 0, fmt.Errorf("not enough data to read")
+		return nil, 0, errors.New("not enough data to read")
 	}
 
 	out := make([]byte, length)
 
 	_, err := hex.Decode(out, data[:read])
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, utils.NewSafeError(err, "failed to perform hex decoding")
 	}
 
 	return out, read, nil
@@ -56,7 +58,7 @@ func (e asciiToHexEncoder) Encode(data []byte) ([]byte, error) {
 
 	_, err := hex.Decode(out, data)
 	if err != nil {
-		return nil, err
+		return nil, utils.NewSafeError(err, "failed to perform hex decoding")
 	}
 
 	return out, nil
@@ -68,7 +70,7 @@ func (e asciiToHexEncoder) Encode(data []byte) ([]byte, error) {
 // 0x2A} would be converted to []byte("5F2A")
 func (e asciiToHexEncoder) Decode(data []byte, length int) ([]byte, int, error) {
 	if length > len(data) {
-		return nil, 0, fmt.Errorf("not enough data to read")
+		return nil, 0, errors.New("not enough data to read")
 	}
 
 	out := make([]byte, hex.EncodedLen(length))

--- a/encoding/hex_test.go
+++ b/encoding/hex_test.go
@@ -18,6 +18,10 @@ func TestHexToASCIIEncoder(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "not enough data to read")
 
+	_, _, err = enc.Decode([]byte("nothex"), 3)
+	require.Error(t, err)
+	require.EqualError(t, err, "failed to perform hex decoding")
+
 	got, err = enc.Encode([]byte{0xAA, 0xBB, 0xCC})
 	require.NoError(t, err)
 	require.Equal(t, []byte("AABBCC"), got)
@@ -34,4 +38,8 @@ func TestASCIIToHexEncoder(t *testing.T) {
 	got, err = enc.Encode([]byte("aabbcc"))
 	require.NoError(t, err)
 	require.Equal(t, []byte{0xAA, 0xBB, 0xCC}, got)
+
+	_, err = enc.Encode([]byte("nothex"))
+	require.Error(t, err)
+	require.EqualError(t, err, "failed to perform hex decoding")
 }

--- a/encoding/lbcd.go
+++ b/encoding/lbcd.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"fmt"
 
+	"github.com/moov-io/iso8583/utils"
 	"github.com/yerden/go-util/bcd"
 )
 
@@ -19,7 +20,7 @@ func (e *lBCDEncoder) Encode(src []byte) ([]byte, error) {
 	dst := make([]byte, bcd.EncodedLen(len(src)))
 	n, err := enc.Encode(dst, src)
 	if err != nil {
-		return nil, err
+		return nil, utils.NewSafeError(err, "failed to perform BCD encoding")
 	}
 
 	return dst[:n], nil
@@ -42,7 +43,7 @@ func (e *lBCDEncoder) Decode(src []byte, length int) ([]byte, int, error) {
 
 	_, err := dec.Decode(dst, src)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, utils.NewSafeError(err, "failed to perform BCD decoding")
 	}
 
 	// because it's left aligned, we return data from

--- a/encoding/lbcd_test.go
+++ b/encoding/lbcd_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yerden/go-util/bcd"
 )
 
 func TestLBCD(t *testing.T) {
@@ -27,12 +28,21 @@ func TestLBCD(t *testing.T) {
 		_, _, err = LBCD.Decode(nil, 5)
 		require.Error(t, err)
 		require.EqualError(t, err, "not enough data to decode. expected len 3, got 0")
+
+		_, _, err = LBCD.Decode([]byte{0xAB, 0xCD}, 4)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD decoding")
+		require.ErrorIs(t, err, bcd.ErrBadBCD)
 	})
 
 	t.Run("Encode", func(t *testing.T) {
 		res, err := LBCD.Encode([]byte("123"))
-
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x12, 0x30}, res)
+
+		_, err = LBCD.Encode([]byte("abc"))
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD encoding")
+		require.ErrorIs(t, err, bcd.ErrBadInput)
 	})
 }

--- a/field/binary.go
+++ b/field/binary.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/utils"
 )
 
 var _ Field = (*Binary)(nil)
@@ -118,7 +119,7 @@ func (f *Binary) SetData(data interface{}) error {
 
 	bin, ok := data.(*Binary)
 	if !ok {
-		return fmt.Errorf("data does not match required *Binary type")
+		return errors.New("data does not match required *Binary type")
 	}
 
 	f.data = bin
@@ -137,19 +138,23 @@ func (f *Binary) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(str)
+	bytes, err := json.Marshal(str)
+	if err != nil {
+		return nil, utils.NewSafeError(err, "failed to JSON marshal string to bytes")
+	}
+	return bytes, nil
 }
 
 func (f *Binary) UnmarshalJSON(b []byte) error {
 	var v string
 	err := json.Unmarshal(b, &v)
 	if err != nil {
-		return fmt.Errorf("failed to JSON unmarshal bytes to string: %w", err)
+		return utils.NewSafeError(err, "failed to JSON unmarshal bytes to string")
 	}
 
 	hex, err := encoding.ASCIIHexToBytes.Encode([]byte(v))
 	if err != nil {
-		return fmt.Errorf("failed to convert ASCII Hex string to bytes")
+		return utils.NewSafeError(err, "failed to convert ASCII Hex string to bytes")
 	}
 	return f.SetBytes(hex)
 }

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -3,6 +3,7 @@ package field
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/moov-io/iso8583/encoding"
@@ -382,7 +383,8 @@ func TestCompositePacking(t *testing.T) {
 		read, err := composite.Unpack([]byte("ABCDEF"))
 		require.Equal(t, 0, read)
 		require.Error(t, err)
-		require.EqualError(t, err, "failed to unpack subfield 3: failed to set bytes: failed to convert into number: strconv.Atoi: parsing \"EF\": invalid syntax")
+		require.EqualError(t, err, "failed to unpack subfield 3: failed to set bytes: failed to convert into number")
+		require.ErrorIs(t, err, strconv.ErrSyntax)
 	})
 
 	t.Run("Unpack returns an error on length of data exceeding max length", func(t *testing.T) {

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 var _ Field = (*Numeric)(nil)
@@ -47,7 +49,7 @@ func (f *Numeric) SetBytes(b []byte) error {
 		// otherwise parse the raw to an int
 		val, err := strconv.Atoi(string(b))
 		if err != nil {
-			return fmt.Errorf("failed to convert into number: %w", err)
+			return utils.NewSafeError(err, "failed to convert into number")
 		}
 		f.Value = val
 	}
@@ -145,14 +147,18 @@ func (f *Numeric) Marshal(data interface{}) error {
 }
 
 func (f *Numeric) MarshalJSON() ([]byte, error) {
-	return json.Marshal(f.Value)
+	bytes, err := json.Marshal(f.Value)
+	if err != nil {
+		return nil, utils.NewSafeError(err, "failed to JSON marshal int to bytes")
+	}
+	return bytes, nil
 }
 
 func (f *Numeric) UnmarshalJSON(b []byte) error {
 	var v int
 	err := json.Unmarshal(b, &v)
 	if err != nil {
-		return fmt.Errorf("failed to JSON unmarshal bytes to int: %w", err)
+		return utils.NewSafeError(err, "failed to JSON unmarshal bytes to int")
 	}
 	return f.SetBytes([]byte(fmt.Sprintf("%d", v)))
 }

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -87,18 +87,18 @@ func TestNumericFieldWithNotANumber(t *testing.T) {
 		Pad:         padding.Left(' '),
 	})
 
-	numeric.SetBytes([]byte("hello"))
+	err := numeric.SetBytes([]byte("hello"))
+	require.Error(t, err)
+	require.EqualError(t, err, "failed to convert into number")
 	require.Equal(t, 0, numeric.Value)
 
 	packed, err := numeric.Pack()
-
 	require.NoError(t, err)
 	require.Equal(t, "         0", string(packed))
 
 	_, err = numeric.Unpack([]byte("hhhhhhhhhh"))
-
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to convert into number")
+	require.EqualError(t, err, "failed to set bytes: failed to convert into number")
 }
 
 func TestNumericFieldZeroLeftPaddedZero(t *testing.T) {

--- a/field/ordered_map.go
+++ b/field/ordered_map.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 // Custom type to sort keys in resulting JSON
@@ -23,7 +25,7 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 	for _, i := range keys {
 		b, err := json.Marshal(om[i])
 		if err != nil {
-			return nil, err
+			return nil, utils.NewSafeError(err, "failed to JSON marshal field to bytes")
 		}
 		buf.WriteString(fmt.Sprintf("\"%v\":", i))
 		buf.Write(b)

--- a/field/string.go
+++ b/field/string.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/moov-io/iso8583/utils"
 )
 
 var _ Field = (*String)(nil)
@@ -131,14 +133,18 @@ func (f *String) Marshal(data interface{}) error {
 }
 
 func (f *String) MarshalJSON() ([]byte, error) {
-	return json.Marshal(f.Value)
+	bytes, err := json.Marshal(f.Value)
+	if err != nil {
+		return nil, utils.NewSafeError(err, "failed to JSON marshal string to bytes")
+	}
+	return bytes, nil
 }
 
 func (f *String) UnmarshalJSON(b []byte) error {
 	var v string
 	err := json.Unmarshal(b, &v)
 	if err != nil {
-		return fmt.Errorf("failed to JSON unmarshal bytes to string: %w", err)
+		return utils.NewSafeError(err, "failed to JSON unmarshal bytes to string")
 	}
 	return f.SetBytes([]byte(v))
 }

--- a/message.go
+++ b/message.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/moov-io/iso8583/field"
+	"github.com/moov-io/iso8583/utils"
 )
 
 var _ json.Marshaler = (*Message)(nil)
@@ -219,7 +220,11 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	}
 
 	// get only fields that were set
-	return json.Marshal(field.OrderedMap(strFieldMap))
+	bytes, err := json.Marshal(field.OrderedMap(strFieldMap))
+	if err != nil {
+		return nil, utils.NewSafeError(err, "failed to JSON marshal map to bytes")
+	}
+	return bytes, nil
 }
 
 func (m *Message) UnmarshalJSON(b []byte) error {
@@ -240,7 +245,7 @@ func (m *Message) UnmarshalJSON(b []byte) error {
 		}
 
 		if err := json.Unmarshal(rawMsg, field); err != nil {
-			return fmt.Errorf("failed to unmarshal field %v: %w", id, err)
+			return utils.NewSafeErrorf(err, "failed to unmarshal field %v", id)
 		}
 
 		m.fieldsMap[i] = struct{}{}

--- a/specs/builder.go
+++ b/specs/builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moov-io/iso8583/padding"
 	"github.com/moov-io/iso8583/prefix"
 	moovsort "github.com/moov-io/iso8583/sort"
+	"github.com/moov-io/iso8583/utils"
 )
 
 type FieldConstructorFunc func(spec *field.Spec) field.Field
@@ -194,7 +195,7 @@ func (builder *messageSpecBuilder) ImportJSON(raw []byte) (*iso8583.MessageSpec,
 	dummySpec := specDummy{}
 	err := json.Unmarshal(raw, &dummySpec)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling spec: %w", err)
+		return nil, utils.NewSafeError(err, "failed to JSON unmarshal bytes to MessageSpec")
 	}
 
 	if len(dummySpec.Fields) == 0 {
@@ -349,7 +350,7 @@ func (builder *messageSpecBuilder) ExportJSON(origSpec *iso8583.MessageSpec) ([]
 	enc.SetIndent("", "\t")
 
 	if err := enc.Encode(dummy); err != nil {
-		return nil, fmt.Errorf("unable to export message spec:  %w", err)
+		return nil, utils.NewSafeError(err, "failed to perform JSON encoding")
 	}
 
 	return outputBuffer.Bytes(), nil

--- a/utils/safe_error.go
+++ b/utils/safe_error.go
@@ -1,0 +1,36 @@
+package utils
+
+import "fmt"
+
+// SafeError wraps an error which may contain sensitive information, allowing
+// it to be matched without exposing sensitive details when logging the error.
+type SafeError struct {
+	Err error
+	Msg string
+}
+
+// NewSafeError returns a new SafeError.
+func NewSafeError(err error, msg string) error {
+	return &SafeError{err, msg}
+}
+
+// NewSafeErrorf returns a new SafeError with formatting.
+func NewSafeErrorf(err error, format string, args ...interface{}) error {
+	return &SafeError{err, fmt.Sprintf(format, args...)}
+}
+
+// Error returns the safe error message.
+func (s *SafeError) Error() string {
+	return s.Msg
+}
+
+// Unwrap returns the wrapped error, which may contain sensitive information.
+func (s *SafeError) Unwrap() error {
+	return s.Err
+}
+
+// UnsafeError returns the full error message, which may contain sensitive
+// information.
+func (s *SafeError) UnsafeError() string {
+	return fmt.Sprintf("%s: %s", s.Msg, s.Err)
+}

--- a/utils/safe_error_test.go
+++ b/utils/safe_error_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeErrorDoesNotExposeSensitiveDetails(t *testing.T) {
+	sensitiveError := errors.New("1234 failed to parse")
+	safeError := &SafeError{
+		Msg: "bad PIN",
+		Err: sensitiveError,
+	}
+	var err error = safeError
+
+	errMsg := fmt.Sprintf("%s", err)
+	require.Equal(t, "bad PIN", errMsg)
+	require.Equal(t, "bad PIN", safeError.Error())
+}
+
+func TestSafeErrorAllowsMatching(t *testing.T) {
+	sensitiveError := errors.New("1234 failed to parse")
+	safeError := &SafeError{
+		Msg: "bad PIN",
+		Err: sensitiveError,
+	}
+	var err error = safeError
+
+	require.ErrorIs(t, err, sensitiveError)
+	require.Equal(t, sensitiveError, safeError.Unwrap())
+}
+
+func TestSafeErrorUnsafeError(t *testing.T) {
+	sensitiveError := errors.New("1234 failed to parse")
+	safeError := &SafeError{
+		Msg: "bad PIN",
+		Err: sensitiveError,
+	}
+
+	require.Equal(t, "bad PIN: 1234 failed to parse", safeError.UnsafeError())
+}


### PR DESCRIPTION
Resolves #103 

Introduce a `SafeError` type (credits to @alovak for the idea!) which is used to wrap around external errors, preventing the returned error message from displaying sensitive information, while still allowing errors to be matched.
Use this new error type to wrap external errors in the `field` and `encoding` packages, as these operate on the potentially sensitive data.

I considered also wrapping external errors in the `prefix` and `network` packages, but since these only operate on the length part of the data, exposing their details _should_ be okay (as long as the message is correctly formatted).