### PR TITLE
feat: support EMV and TLV

### DIFF
--- a/field/constructed_tlv.go
+++ b/field/constructed_tlv.go
@@ -15,7 +15,7 @@ var _ Field = (*ConstructedTLV)(nil)
 var _ json.Marshaler = (*ConstructedTLV)(nil)
 var _ json.Unmarshaler = (*ConstructedTLV)(nil)
 
-// A constructed BER-TLV data object consists of a tag, a length, and a value field
+// ConstructedTLV is a BER-TLV data object consists of a tag, a length, and a value field
 // composed of one or more BER-TLV data objects. A record in an AEF governed by
 // this specification is a constructed BER-TLV data object.
 //
@@ -24,8 +24,6 @@ var _ json.Unmarshaler = (*ConstructedTLV)(nil)
 //						number 1                          number n
 //
 // NOTE: Constructed TLV has not primitive value
-//
-
 type ConstructedTLV struct {
 	spec *Spec
 

--- a/field/constructed_tlv.go
+++ b/field/constructed_tlv.go
@@ -1,0 +1,489 @@
+package field
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/padding"
+	"reflect"
+)
+
+var _ Field = (*ConstructedTLV)(nil)
+var _ json.Marshaler = (*ConstructedTLV)(nil)
+var _ json.Unmarshaler = (*ConstructedTLV)(nil)
+
+// A constructed BER-TLV data object consists of a tag, a length, and a value field
+// composed of one or more BER-TLV data objects. A record in an AEF governed by
+// this specification is a constructed BER-TLV data object.
+//
+//  Tag  Length  Primitive or constructed          Primitive or constructed
+//  (T)   (L)       BER-TLV data object     ...      BER-TLV data object
+//						number 1                          number n
+//
+// NOTE: Constructed TLV has not primitive value
+//
+
+type ConstructedTLV struct {
+	spec *Spec
+
+	orderedSpecFieldTags []string
+
+	// stores all fields according to the spec
+	subfields map[string]Field
+
+	// tracks which subfields were set
+	setSubfields map[string]struct{}
+}
+
+// NewConstructedTLV creates a new instance of the constructed tlv struct,
+func NewConstructedTLV(spec *Spec) *ConstructedTLV {
+	f := &ConstructedTLV{}
+	f.SetSpec(spec)
+	f.ConstructSubfields()
+
+	return f
+}
+
+// NewConstructedTLVValue returns a instance of constructed tlv with value (raw bytes)
+func NewConstructedTLVValue(val []byte) *ConstructedTLV {
+
+	tlv := ConstructedTLV{}
+
+	// Read subfields
+	if err := tlv.SetBytes(val); err != nil {
+		return nil
+	}
+
+	return &tlv
+}
+
+// NewConstructedTLVHexString returns a instance of constructed tlv with hex string
+func NewConstructedTLVHexString(val string) *ConstructedTLV {
+
+	value, err := encoding.BerTLVTag.Encode([]byte(val))
+	if err != nil {
+		return &ConstructedTLV{}
+	}
+
+	tlv := ConstructedTLV{}
+
+	// Read subfields
+	if err := tlv.SetBytes(value); err != nil {
+		return nil
+	}
+
+	return &tlv
+}
+
+func (f *ConstructedTLV) ConstructSubfields() {
+	if f.subfields == nil {
+		f.subfields = CreateSubfields(f.spec)
+	}
+	f.setSubfields = make(map[string]struct{})
+}
+
+// Spec returns the receiver's spec.
+func (f *ConstructedTLV) Spec() *Spec {
+	return f.spec
+}
+
+// getSubfields returns the map of set sub fields
+func (f *ConstructedTLV) getSubfields() map[string]Field {
+	fields := map[string]Field{}
+	for i := range f.setSubfields {
+		fields[i] = f.subfields[i]
+	}
+	return fields
+}
+
+// SetSpec validates the spec and creates new instances of Subfields defined
+// in the specification.
+// NOTE: Composite does not support padding on the base spec. Therefore, users
+// should only pass None or nil values for ths type. Passing any other value
+// will result in a panic.
+func (f *ConstructedTLV) SetSpec(spec *Spec) {
+	if err := validateConstructedTLVSpec(spec); err != nil {
+		panic(err)
+	}
+	f.spec = spec
+	f.orderedSpecFieldTags = orderedKeys(spec.Subfields, spec.Tag.Sort)
+}
+
+func (f *ConstructedTLV) Unmarshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the struct from the pointer
+	dataStruct := rv.Elem()
+
+	if dataStruct.Kind() != reflect.Struct {
+		return errors.New("data is not a struct")
+	}
+
+	// iterate over struct fields
+	for i := 0; i < dataStruct.NumField(); i++ {
+		indexOrTag, err := getFieldIndexOrTag(dataStruct.Type().Field(i))
+		if err != nil {
+			return fmt.Errorf("getting field %d index: %w", i, err)
+		}
+
+		// skip field without index
+		if indexOrTag == "" {
+			continue
+		}
+
+		messageField, ok := f.subfields[indexOrTag]
+		if !ok {
+			continue
+		}
+
+		// unmarshal only subfield that has the value set
+		if _, set := f.setSubfields[indexOrTag]; !set {
+			continue
+		}
+
+		dataField := dataStruct.Field(i)
+		if dataField.IsNil() {
+			dataField.Set(reflect.New(dataField.Type().Elem()))
+		}
+
+		err = messageField.Unmarshal(dataField.Interface())
+		if err != nil {
+			return fmt.Errorf("failed to get data from field %s: %w", indexOrTag, err)
+		}
+	}
+
+	return nil
+}
+
+// Deprecated. Use Marshal instead
+func (f *ConstructedTLV) SetData(v interface{}) error {
+	return f.Marshal(v)
+}
+
+func (f *ConstructedTLV) Marshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the struct from the pointer
+	dataStruct := rv.Elem()
+
+	if dataStruct.Kind() != reflect.Struct {
+		return errors.New("data is not a struct")
+	}
+
+	// iterate over struct fields
+	for i := 0; i < dataStruct.NumField(); i++ {
+		indexOrTag, err := getFieldIndexOrTag(dataStruct.Type().Field(i))
+		if err != nil {
+			return fmt.Errorf("getting field %d index: %w", i, err)
+		}
+
+		// skip field without index
+		if indexOrTag == "" {
+			continue
+		}
+
+		messageField, ok := f.subfields[indexOrTag]
+		if !ok {
+			continue
+		}
+
+		dataField := dataStruct.Field(i)
+		if dataField.IsNil() {
+			continue
+		}
+
+		err = messageField.Marshal(dataField.Interface())
+		if err != nil {
+			return fmt.Errorf("failed to set data from field %s: %w", indexOrTag, err)
+		}
+
+		f.setSubfields[indexOrTag] = struct{}{}
+	}
+
+	return nil
+}
+
+// Pack deserialises data held by the receiver (via SetData)
+// into bytes and returns an error on failure.
+func (f *ConstructedTLV) Pack() ([]byte, error) {
+
+	if f.spec.Tag == nil || f.spec.Tag.Enc == nil || f.spec.Pref == nil || f.spec.Enc == nil {
+		return nil, fmt.Errorf("failed to pack tlv: invalid spec")
+	}
+
+	packed, err := f.pack()
+	if err != nil {
+		return nil, err
+	}
+
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %w", err)
+	}
+
+	packed = append(packedLength, packed...)
+
+	tagBytes := []byte(f.spec.Tag.Tag)
+	if f.spec.Tag.Pad != nil {
+		tagBytes = f.spec.Tag.Pad.Pad(tagBytes, f.spec.Tag.Length)
+	}
+	tagBytes, err = f.spec.Tag.Enc.Encode(tagBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode tlv Tag \"%v\"", tagBytes)
+	}
+	packed = append(tagBytes, packed...)
+
+	return packed, nil
+}
+
+// Unpack takes in a byte array and serializes them into the receiver's
+// subfields. An offset (unit depends on encoding and prefix values) is
+// returned on success. A non-nil error is returned on failure.
+func (f *ConstructedTLV) Unpack(data []byte) (int, error) {
+
+	if f.spec.Tag == nil || f.spec.Tag.Enc == nil || f.spec.Pref == nil {
+		return 0, fmt.Errorf("failed to unpack tlv: invalid spec")
+	}
+
+	offset := 0
+
+	// 1. Read Tag
+
+	tagBytes, read, err := f.spec.Tag.Enc.Decode(data[offset:], f.spec.Tag.Length)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unpack subfield Tag: %w", err)
+	}
+	offset += read
+
+	if f.spec.Tag.Pad != nil {
+		tagBytes = f.spec.Tag.Pad.Unpad(tagBytes)
+	}
+	tag := string(tagBytes)
+
+	if tag != f.spec.Tag.Tag {
+		return 0, fmt.Errorf("tag mismatch: want to read %s, got %s", f.spec.Tag.Tag, tag)
+	}
+
+	// 2. Read Length
+
+	dataLen, read, err := f.spec.Pref.DecodeLength(f.spec.Length, data[offset:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %w", err)
+	}
+	offset += read
+
+	// 3. Read Raw Value
+
+	raw, read, err := f.spec.Enc.Decode(data[offset:], dataLen)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode content: %w", err)
+	}
+
+	if f.spec.Pad != nil {
+		raw = f.spec.Pad.Unpad(raw)
+	}
+	offset += read
+
+	// 4. Read subfields
+	_, err = f.unpack(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return offset, nil
+}
+
+// SetBytes iterates over the receiver's subfields and unpacks them.
+// Data passed into this method must consist of the necessary information to
+// pack all subfields in full. However, unlike Unpack(), it requires the
+// aggregate length of the subfields not to be encoded in the prefix.
+func (f *ConstructedTLV) SetBytes(data []byte) error {
+	_, err := f.unpack(data)
+	return err
+}
+
+// Bytes iterates over the receiver's subfields and packs them. The result
+// does not incorporate the encoded aggregate length of the subfields in the
+// prefix.
+func (f *ConstructedTLV) Bytes() ([]byte, error) {
+	return f.pack()
+}
+
+// String iterates over the receiver's subfields, packs them and converts the
+// result to a string. The result does not incorporate the encoded aggregate
+// length of the subfields in the prefix.
+func (f *ConstructedTLV) String() (string, error) {
+	b, err := f.Bytes()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%X", b), nil
+}
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (f *ConstructedTLV) MarshalJSON() ([]byte, error) {
+	jsonData := OrderedMap(f.getSubfields())
+	return json.Marshal(jsonData)
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+// An error is thrown if the JSON consists of a subfield that has not
+// been defined in the spec.
+func (f *ConstructedTLV) UnmarshalJSON(b []byte) error {
+	var data map[string]json.RawMessage
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+
+	for tag, rawMsg := range data {
+		if _, ok := f.spec.Subfields[tag]; !ok {
+			return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
+		}
+
+		subfield, ok := f.subfields[tag]
+		if !ok {
+			continue
+		}
+
+		if err := json.Unmarshal(rawMsg, subfield); err != nil {
+			return fmt.Errorf("failed to unmarshal subfield %v: %w", tag, err)
+		}
+
+		f.setSubfields[tag] = struct{}{}
+	}
+
+	return nil
+}
+
+func (f *ConstructedTLV) pack() ([]byte, error) {
+
+	packed := []byte{}
+
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return nil, fmt.Errorf("no subfield for tag %s", tag)
+		}
+
+		if _, set := f.setSubfields[tag]; !set {
+			continue
+		}
+
+		packedBytes, err := field.Pack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to pack subfield %v: %w", tag, err)
+		}
+		packed = append(packed, packedBytes...)
+
+	}
+
+	return packed, nil
+}
+
+func (f *ConstructedTLV) unpack(data []byte) (int, error) {
+
+	offset := 0
+
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return 0, fmt.Errorf("no subfield for tag %s", tag)
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil {
+			return 0, fmt.Errorf("no spec for subfield")
+		}
+
+		read, err := field.Unpack(data[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("failed to unpack subfield %v: %w", field.Spec().Tag.Tag, err)
+		}
+
+		f.setSubfields[tag] = struct{}{}
+
+		offset += read
+	}
+
+	return offset, nil
+}
+
+func validateConstructedTLVSpec(spec *Spec) error {
+	if spec.Tag == nil || spec.Tag.Tag == "" {
+		return fmt.Errorf("ConstructedTLV spec requires a Tag.tag value to be defined")
+	}
+	if spec.Pad != nil && spec.Pad != padding.None {
+		return fmt.Errorf("ConstructedTLV spec only supports nil or None spec padding values")
+	}
+	if spec.Enc == nil {
+		return fmt.Errorf("ConstructedTLV spec only supports a valid Enc value")
+	}
+	if spec.Tag != nil && spec.Tag.Enc == nil {
+		return fmt.Errorf("ConstructedTLV spec requires a Tag.Enc")
+	}
+	if spec.Tag.Sort == nil {
+		return fmt.Errorf("ConstructedTLV spec requires a Tag.Sort function to be defined")
+	}
+	return nil
+}
+
+// GetValue returns value of specified tag
+func (f *ConstructedTLV) GetValue(tagHex string) ([]byte, error) {
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return nil, fmt.Errorf("unabled to find the tag %s", tagHex)
+		}
+
+		if sub, ok := field.(*ConstructedTLV); ok {
+			value, getErr := sub.GetValue(tagHex)
+			if getErr == nil {
+				return value, nil
+			}
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil || field.Spec().Tag.Tag == "" {
+			return nil, fmt.Errorf("no spec for the tag  %s", tagHex)
+		}
+
+		if field.Spec().Tag.Tag == tagHex {
+			return field.Bytes()
+		}
+	}
+
+	return nil, fmt.Errorf("unabled to find the tag %s", tagHex)
+}
+
+// SetValue set value of tlv with specified tag
+func (f *ConstructedTLV) SetValue(tagHex string, value []byte) error {
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return fmt.Errorf("unabled to find the tag %s", tagHex)
+		}
+
+		if sub, ok := field.(*ConstructedTLV); ok {
+			getErr := sub.SetValue(tagHex, value)
+			if getErr == nil {
+				return nil
+			}
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil || field.Spec().Tag.Tag == "" {
+			return fmt.Errorf("no spec for the tag  %s", tagHex)
+		}
+
+		if field.Spec().Tag.Tag == tagHex {
+			return field.SetBytes(value)
+		}
+	}
+
+	return fmt.Errorf("unabled to find the tag %s", tagHex)
+}

--- a/field/constructed_tlv.go
+++ b/field/constructed_tlv.go
@@ -108,16 +108,16 @@ func (f *ConstructedTLV) describe(output io.Writer, padLeft int) {
 		}
 
 		fmtStr := "%s\t:"
-		for i:=0; i<padLeft;i++ {
+		for i := 0; i < padLeft; i++ {
 			// spaces for tree levels
 			fmtStr = "  " + fmtStr
 		}
 
 		if sub, ok := field.(*PrimitiveTLV); ok {
 			raw, _ := sub.Bytes()
-			fmt.Fprintf(output, fmtStr + " %X\n", field.Spec().Tag.Tag, raw)
+			fmt.Fprintf(output, fmtStr+" %X\n", field.Spec().Tag.Tag, raw)
 		} else if sub, ok := field.(*ConstructedTLV); ok {
-			fmt.Fprintf(output, fmtStr + "\n", field.Spec().Tag.Tag)
+			fmt.Fprintf(output, fmtStr+"\n", field.Spec().Tag.Tag)
 			sub.describe(output, padLeft+1)
 		}
 	}

--- a/field/constructed_tlv_test.go
+++ b/field/constructed_tlv_test.go
@@ -170,6 +170,7 @@ func TestConstructedTLVUnpacking(t *testing.T) {
 			},
 		}
 		err := tlv.SetData(dummy)
+		require.NoError(t, err)
 
 		read, err := tlv.Unpack(raw)
 		require.NoError(t, err)

--- a/field/constructed_tlv_test.go
+++ b/field/constructed_tlv_test.go
@@ -1,6 +1,7 @@
 package field
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -83,7 +84,7 @@ type ConstructedTerminal struct {
 	F03 *ConstructedCurrencyCode
 }
 
-func TestConstructedTLVPacking(t *testing.T) {
+func TestConstructedTLV_Packing(t *testing.T) {
 	t.Run("Pack returns an null tlv when setting mismatched struct", func(t *testing.T) {
 		type TestDataIncorrectType struct {
 			F1 *PrimitiveTLV
@@ -141,7 +142,7 @@ func TestConstructedTLVPacking(t *testing.T) {
 	})
 }
 
-func TestConstructedTLVUnpacking(t *testing.T) {
+func TestConstructedTLV_Unpacking(t *testing.T) {
 
 	hexString := "9F33118202017F9F3602027F9F3B059F4502047F"
 	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
@@ -186,7 +187,7 @@ func TestConstructedTLVUnpacking(t *testing.T) {
 	})
 }
 
-func TestConstructedTLVGetSetBytes(t *testing.T) {
+func TestConstructedTLV_GetSetBytes(t *testing.T) {
 
 	hexString := "9F33118202017F9F3602027F9F3B059F4502047F"
 	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
@@ -213,7 +214,7 @@ func TestConstructedTLVGetSetBytes(t *testing.T) {
 	require.Equal(t, "failed to unpack subfield 82: tag mismatch: want to read 82, got 9F33", err.Error())
 }
 
-func TestConstructedTLVGetValue(t *testing.T) {
+func TestConstructedTLV_GetValue(t *testing.T) {
 
 	tlv := NewConstructedTLV(constructedTestSpec)
 
@@ -232,7 +233,7 @@ func TestConstructedTLVGetValue(t *testing.T) {
 
 }
 
-func TestConstructedTLVSetValue(t *testing.T) {
+func TestConstructedTLV_SetValue(t *testing.T) {
 
 	tlv := NewConstructedTLV(constructedTestSpec)
 
@@ -252,4 +253,23 @@ func TestConstructedTLVSetValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "046F", fmt.Sprintf("%X", value))
 
+}
+
+func TestConstructedTLV_describe(t *testing.T) {
+
+	tlv := NewConstructedTLV(constructedTestSpec)
+
+	err := tlv.SetData(&ConstructedTerminal{
+		F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+		F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+		F03: &ConstructedCurrencyCode{
+			F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+		},
+	})
+	require.NoError(t, err)
+
+	buf := bytes.NewBufferString("")
+	tlv.describe(buf, 0)
+
+	require.Equal(t, "82\t: 017F\n9F36\t: 027F\n9F3B\t:\n  9F45\t: 047F\n", buf.String())
 }

--- a/field/constructed_tlv_test.go
+++ b/field/constructed_tlv_test.go
@@ -1,0 +1,254 @@
+package field
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	constructedTestSpec = &Spec{
+		Length:      3,
+		Description: "Terminal Capabilities",
+		Enc:         encoding.Binary,
+		Pref:        prefix.BerTLV,
+		Tag: &TagSpec{
+			Tag:  "9F33",
+			Enc:  encoding.BerTLVTag,
+			Sort: sort.StringsByHex,
+		},
+		Subfields: map[string]Field{
+			"01": NewPrimitiveTLV(&Spec{
+				Length:      2,
+				Description: "Application Interchange Profile",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "82",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+			}),
+			"02": NewPrimitiveTLV(&Spec{
+				Length:      2,
+				Description: "Application Transaction Counter",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "9F36",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+			}),
+			"03": NewConstructedTLV(&Spec{
+				Length:      8,
+				Description: "Currency Code, Application Reference",
+				Enc:         encoding.Binary,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "9F3B",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+				Subfields: map[string]Field{
+					"04": NewPrimitiveTLV(&Spec{
+						Length:      2,
+						Description: "Data Authentication Code",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.BerTLV,
+						Tag: &TagSpec{
+							Tag:  "9F45",
+							Enc:  encoding.BerTLVTag,
+							Sort: sort.StringsByHex,
+						},
+					}),
+				},
+			}),
+		},
+	}
+)
+
+type ConstructedCurrencyCode struct {
+	F04 *PrimitiveTLV
+}
+
+type ConstructedTerminal struct {
+	F01 *PrimitiveTLV
+	F02 *PrimitiveTLV
+	F03 *ConstructedCurrencyCode
+}
+
+func TestConstructedTLVPacking(t *testing.T) {
+	t.Run("Pack returns an null tlv when setting mismatched struct", func(t *testing.T) {
+		type TestDataIncorrectType struct {
+			F1 *PrimitiveTLV
+		}
+		tlv := NewConstructedTLV(constructedTestSpec)
+		err := tlv.SetData(&TestDataIncorrectType{
+			F1: NewPrimitiveTLVValue([]byte{0x0, 0x93}),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 0, len(tlv.getSubfields()))
+
+		packed, err := tlv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x9F, 0x33, 0x00}, packed)
+	})
+
+	t.Run("Pack returns nested tlv struct", func(t *testing.T) {
+
+		tlv := NewConstructedTLV(constructedTestSpec)
+
+		err := tlv.SetData(&ConstructedTerminal{
+			F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+			F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+			F03: &ConstructedCurrencyCode{
+				F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+			},
+		})
+		require.NoError(t, err)
+
+		packed, err := tlv.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, "9F33118202017F9F3602027F9F3B059F4502047F", fmt.Sprintf("%X", packed))
+	})
+
+	t.Run("Pack returns an error on failure of invalid value", func(t *testing.T) {
+		tlv := NewConstructedTLV(constructedTestSpec)
+
+		err := tlv.SetData(&ConstructedTerminal{
+			F01: NewPrimitiveTLVValue([]byte{0x01, 0xff}),
+			F02: NewPrimitiveTLVValue([]byte{0x02, 0xff}),
+			F03: &ConstructedCurrencyCode{
+				F04: NewPrimitiveTLVValue([]byte{0x04, 0xff}),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = tlv.Pack()
+		require.Error(t, err)
+		require.Equal(
+			t,
+			"failed to pack subfield 01: failed to encode content: failed to perform ASCII encoding",
+			err.Error())
+	})
+}
+
+func TestConstructedTLVUnpacking(t *testing.T) {
+
+	hexString := "9F33118202017F9F3602027F9F3B059F4502047F"
+	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
+	require.NoError(t, err)
+
+	t.Run("Unpack decode raw bytes without any struct mapping", func(t *testing.T) {
+		tlv := NewConstructedTLV(constructedTestSpec)
+
+		read, err := tlv.Unpack(raw)
+		require.NoError(t, err)
+		require.Equal(t, 20, read)
+
+		packed, err := tlv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+	})
+
+	t.Run("Unpack decode raw bytes with struct mapping", func(t *testing.T) {
+		tlv := NewConstructedTLV(constructedTestSpec)
+
+		dummy := &ConstructedTerminal{
+			F01: NewPrimitiveTLVValue(nil),
+			F02: NewPrimitiveTLVValue(nil),
+			F03: &ConstructedCurrencyCode{
+				F04: NewPrimitiveTLVValue(nil),
+			},
+		}
+		err := tlv.SetData(dummy)
+
+		read, err := tlv.Unpack(raw)
+		require.NoError(t, err)
+		require.Equal(t, 20, read)
+
+		packed, err := tlv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+
+		jsonStr, err := json.Marshal(dummy)
+		require.NoError(t, err)
+		require.Equal(t, `{"F01":"017F","F02":"027F","F03":{"F04":"047F"}}`, string(jsonStr))
+	})
+}
+
+func TestConstructedTLVGetSetBytes(t *testing.T) {
+
+	hexString := "9F33118202017F9F3602027F9F3B059F4502047F"
+	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
+	require.NoError(t, err)
+
+	valueString := "8202017F9F3602027F9F3B059F4502047F"
+	value, err := encoding.BerTLVTag.Encode([]byte(valueString))
+	require.NoError(t, err)
+
+	tlv := NewConstructedTLV(constructedTestSpec)
+	err = tlv.SetBytes(value)
+	require.NoError(t, err)
+
+	packed, err := tlv.Pack()
+	require.NoError(t, err)
+	require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+
+	gotValue, err := tlv.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, valueString, fmt.Sprintf("%X", gotValue))
+
+	err = tlv.SetBytes(raw)
+	require.Error(t, err)
+	require.Equal(t, "failed to unpack subfield 82: tag mismatch: want to read 82, got 9F33", err.Error())
+}
+
+func TestConstructedTLVGetValue(t *testing.T) {
+
+	tlv := NewConstructedTLV(constructedTestSpec)
+
+	err := tlv.SetData(&ConstructedTerminal{
+		F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+		F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+		F03: &ConstructedCurrencyCode{
+			F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+		},
+	})
+	require.NoError(t, err)
+
+	value, err := tlv.GetValue("9F45")
+	require.NoError(t, err)
+	require.Equal(t, "047F", fmt.Sprintf("%X", value))
+
+}
+
+func TestConstructedTLVSetValue(t *testing.T) {
+
+	tlv := NewConstructedTLV(constructedTestSpec)
+
+	err := tlv.SetData(&ConstructedTerminal{
+		F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+		F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+		F03: &ConstructedCurrencyCode{
+			F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+		},
+	})
+	require.NoError(t, err)
+
+	err = tlv.SetValue("9F45", []byte{0x04, 0x6f})
+	require.NoError(t, err)
+
+	value, err := tlv.GetValue("9F45")
+	require.NoError(t, err)
+	require.Equal(t, "046F", fmt.Sprintf("%X", value))
+
+}

--- a/field/emv.go
+++ b/field/emv.go
@@ -210,22 +210,12 @@ func (f *EMV) Unpack(data []byte) (int, error) {
 	}
 	offset += read
 
-	raw, read, err := f.spec.Enc.Decode(data[offset:], dataLen)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode content: %w", err)
-	}
-
-	if f.spec.Pad != nil {
-		raw = f.spec.Pad.Unpad(raw)
-	}
-	offset += read
-
-	_, err = f.unpack(raw)
+	read, err = f.unpack(data[offset : offset+dataLen])
 	if err != nil {
 		return 0, err
 	}
 
-	return offset, nil
+	return offset + read, nil
 }
 
 // SetBytes iterates over the receiver's subfields and unpacks them.
@@ -346,9 +336,6 @@ func (f *EMV) unpack(data []byte) (int, error) {
 func validateEMVSpec(spec *Spec) error {
 	if spec.Pad != nil && spec.Pad != padding.None {
 		return fmt.Errorf("EMV spec only supports nil or None spec padding values")
-	}
-	if spec.Enc == nil {
-		return fmt.Errorf("EMV spec only supports a valid Enc value")
 	}
 	if spec.Pref == nil {
 		return fmt.Errorf("EMV spec only supports a valid pref")

--- a/field/emv.go
+++ b/field/emv.go
@@ -1,0 +1,414 @@
+package field
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/moov-io/iso8583/padding"
+)
+
+var _ Field = (*EMV)(nil)
+var _ json.Marshaler = (*EMV)(nil)
+var _ json.Unmarshaler = (*EMV)(nil)
+
+// EMV is a payment method based on a technical standard for smart payment cards and for payment terminals
+// and automated teller machines which can accept them. EMV stands for "Europay, Mastercard, and Visa",
+// the three companies that created the standard.
+//
+// EMV cards are smart cards, also called chip cards, integrated circuit cards, or IC cards,
+// which store their data on integrated circuit chips, in addition to magnetic stripes for backward compatibility.
+//
+// ISO 8583 – Field or DE 55 has the EMV data encoded in the authorization message.
+//
+
+type EMV struct {
+	spec *Spec
+
+	orderedSpecFieldTags []string
+
+	// stores all fields according to the spec
+	subfields map[string]Field
+
+	// tracks which subfields were set
+	setSubfields map[string]struct{}
+}
+
+// NewEMV creates a new instance of the constructed tlv struct,
+func NewEMV(spec *Spec) *EMV {
+	f := &EMV{}
+	f.SetSpec(spec)
+	f.ConstructSubfields()
+
+	return f
+}
+
+func (f *EMV) ConstructSubfields() {
+	if f.subfields == nil {
+		f.subfields = CreateSubfields(f.spec)
+	}
+	f.setSubfields = make(map[string]struct{})
+}
+
+// Spec returns the receiver's spec.
+func (f *EMV) Spec() *Spec {
+	return f.spec
+}
+
+// getSubfields returns the map of set sub fields
+func (f *EMV) getSubfields() map[string]Field {
+	fields := map[string]Field{}
+	for i := range f.setSubfields {
+		fields[i] = f.subfields[i]
+	}
+	return fields
+}
+
+// SetSpec validates the spec and creates new instances of Subfields defined
+// in the specification.
+// NOTE: Composite does not support padding on the base spec. Therefore, users
+// should only pass None or nil values for ths type. Passing any other value
+// will result in a panic.
+func (f *EMV) SetSpec(spec *Spec) {
+	if err := validateEMVSpec(spec); err != nil {
+		panic(err)
+	}
+	f.spec = spec
+	f.orderedSpecFieldTags = orderedKeys(spec.Subfields, spec.Tag.Sort)
+}
+
+func (f *EMV) Unmarshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the struct from the pointer
+	dataStruct := rv.Elem()
+
+	if dataStruct.Kind() != reflect.Struct {
+		return errors.New("data is not a struct")
+	}
+
+	// iterate over struct fields
+	for i := 0; i < dataStruct.NumField(); i++ {
+		indexOrTag, err := getFieldIndexOrTag(dataStruct.Type().Field(i))
+		if err != nil {
+			return fmt.Errorf("getting field %d index: %w", i, err)
+		}
+
+		// skip field without index
+		if indexOrTag == "" {
+			continue
+		}
+
+		messageField, ok := f.subfields[indexOrTag]
+		if !ok {
+			continue
+		}
+
+		// unmarshal only subfield that has the value set
+		if _, set := f.setSubfields[indexOrTag]; !set {
+			continue
+		}
+
+		dataField := dataStruct.Field(i)
+		if dataField.IsNil() {
+			dataField.Set(reflect.New(dataField.Type().Elem()))
+		}
+
+		err = messageField.Unmarshal(dataField.Interface())
+		if err != nil {
+			return fmt.Errorf("failed to get data from field %s: %w", indexOrTag, err)
+		}
+	}
+
+	return nil
+}
+
+// Deprecated. Use Marshal instead
+func (f *EMV) SetData(v interface{}) error {
+	return f.Marshal(v)
+}
+
+func (f *EMV) Marshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the struct from the pointer
+	dataStruct := rv.Elem()
+
+	if dataStruct.Kind() != reflect.Struct {
+		return errors.New("data is not a struct")
+	}
+
+	// iterate over struct fields
+	for i := 0; i < dataStruct.NumField(); i++ {
+		indexOrTag, err := getFieldIndexOrTag(dataStruct.Type().Field(i))
+		if err != nil {
+			return fmt.Errorf("getting field %d index: %w", i, err)
+		}
+
+		// skip field without index
+		if indexOrTag == "" {
+			continue
+		}
+
+		messageField, ok := f.subfields[indexOrTag]
+		if !ok {
+			continue
+		}
+
+		dataField := dataStruct.Field(i)
+		if dataField.IsNil() {
+			continue
+		}
+
+		err = messageField.Marshal(dataField.Interface())
+		if err != nil {
+			return fmt.Errorf("failed to set data from field %s: %w", indexOrTag, err)
+		}
+
+		f.setSubfields[indexOrTag] = struct{}{}
+	}
+
+	return nil
+}
+
+// Pack deserialises data held by the receiver (via SetData)
+// into bytes and returns an error on failure.
+func (f *EMV) Pack() ([]byte, error) {
+
+	packed, err := f.pack()
+	if err != nil {
+		return nil, err
+	}
+
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %w", err)
+	}
+
+	packed = append(packedLength, packed...)
+
+	return packed, nil
+}
+
+// Unpack takes in a byte array and serializes them into the receiver's
+// subfields. An offset (unit depends on encoding and prefix values) is
+// returned on success. A non-nil error is returned on failure.
+func (f *EMV) Unpack(data []byte) (int, error) {
+
+	offset := 0
+
+	dataLen, read, err := f.spec.Pref.DecodeLength(f.spec.Length, data[offset:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %w", err)
+	}
+	offset += read
+
+	raw, read, err := f.spec.Enc.Decode(data[offset:], dataLen)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode content: %w", err)
+	}
+
+	if f.spec.Pad != nil {
+		raw = f.spec.Pad.Unpad(raw)
+	}
+	offset += read
+
+	_, err = f.unpack(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return offset, nil
+}
+
+// SetBytes iterates over the receiver's subfields and unpacks them.
+// Data passed into this method must consist of the necessary information to
+// pack all subfields in full. However, unlike Unpack(), it requires the
+// aggregate length of the subfields not to be encoded in the prefix.
+func (f *EMV) SetBytes(data []byte) error {
+	_, err := f.unpack(data)
+	return err
+}
+
+// Bytes iterates over the receiver's subfields and packs them. The result
+// does not incorporate the encoded aggregate length of the subfields in the
+// prefix.
+func (f *EMV) Bytes() ([]byte, error) {
+	return f.pack()
+}
+
+// String iterates over the receiver's subfields, packs them and converts the
+// result to a string. The result does not incorporate the encoded aggregate
+// length of the subfields in the prefix.
+func (f *EMV) String() (string, error) {
+	b, err := f.Bytes()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%X", b), nil
+}
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (f *EMV) MarshalJSON() ([]byte, error) {
+	jsonData := OrderedMap(f.getSubfields())
+	return json.Marshal(jsonData)
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+// An error is thrown if the JSON consists of a subfield that has not
+// been defined in the spec.
+func (f *EMV) UnmarshalJSON(b []byte) error {
+	var data map[string]json.RawMessage
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+
+	for tag, rawMsg := range data {
+		if _, ok := f.spec.Subfields[tag]; !ok {
+			return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
+		}
+
+		subfield, ok := f.subfields[tag]
+		if !ok {
+			continue
+		}
+
+		if err := json.Unmarshal(rawMsg, subfield); err != nil {
+			return fmt.Errorf("failed to unmarshal subfield %v: %w", tag, err)
+		}
+
+		f.setSubfields[tag] = struct{}{}
+	}
+
+	return nil
+}
+
+func (f *EMV) pack() ([]byte, error) {
+
+	packed := []byte{}
+
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return nil, fmt.Errorf("no subfield for tag %s", tag)
+		}
+
+		if _, set := f.setSubfields[tag]; !set {
+			continue
+		}
+
+		packedBytes, err := field.Pack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to pack subfield %v: %w", tag, err)
+		}
+		packed = append(packed, packedBytes...)
+
+	}
+
+	return packed, nil
+}
+
+func (f *EMV) unpack(data []byte) (int, error) {
+
+	offset := 0
+
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return 0, fmt.Errorf("no subfield for tag %s", tag)
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil {
+			return 0, fmt.Errorf("no spec for subfield")
+		}
+
+		read, err := field.Unpack(data[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("failed to unpack subfield %v: %w", field.Spec().Tag.Tag, err)
+		}
+
+		f.setSubfields[tag] = struct{}{}
+
+		offset += read
+	}
+
+	return offset, nil
+}
+
+func validateEMVSpec(spec *Spec) error {
+	if spec.Pad != nil && spec.Pad != padding.None {
+		return fmt.Errorf("EMV spec only supports nil or None spec padding values")
+	}
+	if spec.Enc == nil {
+		return fmt.Errorf("EMV spec only supports a valid Enc value")
+	}
+	if spec.Pref == nil {
+		return fmt.Errorf("EMV spec only supports a valid pref")
+	}
+	if spec.Tag.Sort == nil {
+		return fmt.Errorf("EMV spec requires a Tag.Sort function to be defined")
+	}
+	return nil
+}
+
+// GetValue returns value of specified tag
+func (f *EMV) GetValue(tagHex string) ([]byte, error) {
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return nil, fmt.Errorf("unabled to find the tag %s", tagHex)
+		}
+
+		if sub, ok := field.(*ConstructedTLV); ok {
+			value, getErr := sub.GetValue(tagHex)
+			if getErr == nil {
+				return value, nil
+			}
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil || field.Spec().Tag.Tag == "" {
+			return nil, fmt.Errorf("no spec for the tag  %s", tagHex)
+		}
+
+		if field.Spec().Tag.Tag == tagHex {
+			return field.Bytes()
+		}
+	}
+
+	return nil, fmt.Errorf("unabled to find the tag %s", tagHex)
+}
+
+// SetValue set value of sub tlv with specified tag
+func (f *EMV) SetValue(tagHex string, value []byte) error {
+	for _, tag := range f.orderedSpecFieldTags {
+		field, ok := f.subfields[tag]
+		if !ok {
+			return fmt.Errorf("unabled to find the tag %s", tagHex)
+		}
+
+		if sub, ok := field.(*ConstructedTLV); ok {
+			getErr := sub.SetValue(tagHex, value)
+			if getErr == nil {
+				return nil
+			}
+		}
+
+		if field.Spec() == nil || field.Spec().Tag == nil || field.Spec().Tag.Tag == "" {
+			return fmt.Errorf("no spec for the tag  %s", tagHex)
+		}
+
+		if field.Spec().Tag.Tag == tagHex {
+			return field.SetBytes(value)
+		}
+	}
+
+	return fmt.Errorf("unabled to find the tag %s", tagHex)
+}

--- a/field/emv_tlv_test.go
+++ b/field/emv_tlv_test.go
@@ -1,0 +1,251 @@
+package field
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	emvTestSpec = &Spec{
+		Length:      999,
+		Description: "ICC Data – EMV Having Multiple Tags",
+		Pref:        prefix.ASCII.LLL,
+		Tag: &TagSpec{
+			Sort: sort.StringsByHex,
+		},
+		Subfields: map[string]Field{
+			"01": NewPrimitiveTLV(&Spec{
+				Length:      2,
+				Description: "Application Interchange Profile",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "82",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+			}),
+			"02": NewPrimitiveTLV(&Spec{
+				Length:      2,
+				Description: "Application Transaction Counter",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "9F36",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+			}),
+			"03": NewConstructedTLV(&Spec{
+				Length:      8,
+				Description: "Currency Code, Application Reference",
+				Enc:         encoding.Binary,
+				Pref:        prefix.BerTLV,
+				Tag: &TagSpec{
+					Tag:  "9F3B",
+					Enc:  encoding.BerTLVTag,
+					Sort: sort.StringsByHex,
+				},
+				Subfields: map[string]Field{
+					"04": NewPrimitiveTLV(&Spec{
+						Length:      2,
+						Description: "Data Authentication Code",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.BerTLV,
+						Tag: &TagSpec{
+							Tag:  "9F45",
+							Enc:  encoding.BerTLVTag,
+							Sort: sort.StringsByHex,
+						},
+					}),
+				},
+			}),
+		},
+	}
+)
+
+type ConstructedData struct {
+	F04 *PrimitiveTLV
+}
+
+type EMVDummy struct {
+	F01 *PrimitiveTLV
+	F02 *PrimitiveTLV
+	F03 *ConstructedData
+}
+
+func TestEMVPacking(t *testing.T) {
+	t.Run("Pack returns an null tlv when setting mismatched struct", func(t *testing.T) {
+		type TestDataIncorrectType struct {
+			F1 *PrimitiveTLV
+		}
+		emv := NewEMV(constructedTestSpec)
+		err := emv.SetData(&TestDataIncorrectType{
+			F1: NewPrimitiveTLVValue([]byte{0x0, 0x93}),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 0, len(emv.getSubfields()))
+
+		packed, err := emv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x0}, packed)
+	})
+
+	t.Run("Pack returns nested tlv struct", func(t *testing.T) {
+
+		emv := NewEMV(constructedTestSpec)
+
+		err := emv.SetData(&EMVDummy{
+			F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+			F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+			F03: &ConstructedData{
+				F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+			},
+		})
+		require.NoError(t, err)
+
+		packed, err := emv.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, "118202017F9F3602027F9F3B059F4502047F", fmt.Sprintf("%X", packed))
+	})
+
+	t.Run("Pack returns an error on failure of invalid value", func(t *testing.T) {
+		emv := NewEMV(constructedTestSpec)
+
+		err := emv.SetData(&EMVDummy{
+			F01: NewPrimitiveTLVValue([]byte{0x01, 0xff}),
+			F02: NewPrimitiveTLVValue([]byte{0x02, 0xff}),
+			F03: &ConstructedData{
+				F04: NewPrimitiveTLVValue([]byte{0x04, 0xff}),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = emv.Pack()
+		require.Error(t, err)
+		require.Equal(
+			t,
+			"failed to pack subfield 01: failed to encode content: failed to perform ASCII encoding",
+			err.Error())
+	})
+}
+
+func TestEMVUnpacking(t *testing.T) {
+
+	hexString := "118202017F9F3602027F9F3B059F4502047F"
+	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
+	require.NoError(t, err)
+
+	t.Run("Unpack decode raw bytes without any struct mapping", func(t *testing.T) {
+		emv := NewEMV(constructedTestSpec)
+
+		read, err := emv.Unpack(raw)
+		require.NoError(t, err)
+		require.Equal(t, 18, read)
+
+		packed, err := emv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+	})
+
+	t.Run("Unpack decode raw bytes with struct mapping", func(t *testing.T) {
+		emv := NewEMV(constructedTestSpec)
+
+		dummy := &EMVDummy{
+			F01: NewPrimitiveTLVValue(nil),
+			F02: NewPrimitiveTLVValue(nil),
+			F03: &ConstructedData{
+				F04: NewPrimitiveTLVValue(nil),
+			},
+		}
+		err := emv.SetData(dummy)
+
+		read, err := emv.Unpack(raw)
+		require.NoError(t, err)
+		require.Equal(t, 18, read)
+
+		packed, err := emv.Pack()
+		require.NoError(t, err)
+		require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+
+		jsonStr, err := json.Marshal(dummy)
+		require.NoError(t, err)
+		require.Equal(t, `{"F01":"017F","F02":"027F","F03":{"F04":"047F"}}`, string(jsonStr))
+	})
+}
+
+func TestEMVGetSetBytes(t *testing.T) {
+
+	hexString := "118202017F9F3602027F9F3B059F4502047F"
+	raw, err := encoding.BerTLVTag.Encode([]byte(hexString))
+	require.NoError(t, err)
+
+	valueString := "8202017F9F3602027F9F3B059F4502047F"
+	value, err := encoding.BerTLVTag.Encode([]byte(valueString))
+	require.NoError(t, err)
+
+	emv := NewEMV(constructedTestSpec)
+	err = emv.SetBytes(value)
+	require.NoError(t, err)
+
+	packed, err := emv.Pack()
+	require.NoError(t, err)
+	require.Equal(t, hexString, fmt.Sprintf("%X", packed))
+
+	gotValue, err := emv.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, valueString, fmt.Sprintf("%X", gotValue))
+
+	err = emv.SetBytes(raw)
+	require.Error(t, err)
+	require.Equal(t, "failed to unpack subfield 82: tag mismatch: want to read 82, got 11", err.Error())
+}
+
+func TestEMVGetValue(t *testing.T) {
+
+	emv := NewEMV(constructedTestSpec)
+
+	err := emv.SetData(&EMVDummy{
+		F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+		F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+		F03: &ConstructedData{
+			F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+		},
+	})
+	require.NoError(t, err)
+
+	value, err := emv.GetValue("9F45")
+	require.NoError(t, err)
+	require.Equal(t, "047F", fmt.Sprintf("%X", value))
+
+}
+
+func TestEMVSetValue(t *testing.T) {
+
+	emv := NewEMV(constructedTestSpec)
+
+	err := emv.SetData(&EMVDummy{
+		F01: NewPrimitiveTLVValue([]byte{0x01, 0x7f}),
+		F02: NewPrimitiveTLVValue([]byte{0x02, 0x7f}),
+		F03: &ConstructedData{
+			F04: NewPrimitiveTLVValue([]byte{0x04, 0x7f}),
+		},
+	})
+	require.NoError(t, err)
+
+	err = emv.SetValue("9F45", []byte{0x04, 0x6f})
+	require.NoError(t, err)
+
+	value, err := emv.GetValue("9F45")
+	require.NoError(t, err)
+	require.Equal(t, "046F", fmt.Sprintf("%X", value))
+
+}

--- a/field/emv_tlv_test.go
+++ b/field/emv_tlv_test.go
@@ -167,6 +167,7 @@ func TestEMVUnpacking(t *testing.T) {
 			},
 		}
 		err := emv.SetData(dummy)
+		require.NoError(t, err)
 
 		read, err := emv.Unpack(raw)
 		require.NoError(t, err)

--- a/field/primitive_tlv.go
+++ b/field/primitive_tlv.go
@@ -1,0 +1,234 @@
+package field
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/moov-io/iso8583/encoding"
+)
+
+var _ Field = (*PrimitiveTLV)(nil)
+var _ json.Marshaler = (*PrimitiveTLV)(nil)
+var _ json.Unmarshaler = (*PrimitiveTLV)(nil)
+
+// A data element is the value field (V) of a primitive BER-TLV data object. A data
+// element is the smallest data field that receives an identifier (a tag).
+//
+//  Tag  Length  Value
+//  (T)   (L)     (V)
+//
+
+type PrimitiveTLV struct {
+	Value []byte `json:"value,omitempty"`
+
+	spec *Spec
+	data *PrimitiveTLV
+}
+
+// NewPrimitiveTLV returns a instance of primitive tlv with spec
+func NewPrimitiveTLV(spec *Spec) *PrimitiveTLV {
+	return &PrimitiveTLV{
+		spec: spec,
+	}
+}
+
+// NewPrimitiveTLVValue returns a instance of primitive tlv with value (raw bytes)
+func NewPrimitiveTLVValue(val []byte) *PrimitiveTLV {
+	return &PrimitiveTLV{
+		Value: val,
+	}
+}
+
+// NewPrimitiveTLVHexString returns a instance of primitive tlv with hex string
+func NewPrimitiveTLVHexString(val string) *PrimitiveTLV {
+	value, err := encoding.BerTLVTag.Encode([]byte(val))
+
+	if err != nil {
+		return &PrimitiveTLV{}
+	}
+
+	return &PrimitiveTLV{
+		Value: value,
+	}
+}
+
+// Spec returns a specification of tlv field
+func (f *PrimitiveTLV) Spec() *Spec {
+	return f.spec
+}
+
+// SetSpec set specification into a tlv field
+func (f *PrimitiveTLV) SetSpec(spec *Spec) {
+	f.spec = spec
+}
+
+// SetBytes set value of tlv field (only value)
+func (f *PrimitiveTLV) SetBytes(b []byte) error {
+	f.Value = b
+	if f.data != nil {
+		*(f.data) = *f
+	}
+	return nil
+}
+
+// Bytes returns raw value of tlv
+func (f *PrimitiveTLV) Bytes() ([]byte, error) {
+	return f.Value, nil
+}
+
+// Bytes returns hex string of value of tlv
+func (f *PrimitiveTLV) String() (string, error) {
+	return fmt.Sprintf("%X", f.Value), nil
+}
+
+// Pack returns encoded bytes for tlv (Tag + Length + Value)
+func (f *PrimitiveTLV) Pack() ([]byte, error) {
+
+	if f.spec.Tag == nil || f.spec.Tag.Enc == nil || f.spec.Pref == nil || f.spec.Enc == nil {
+		return nil, fmt.Errorf("failed to pack tlv: invalid spec")
+	}
+
+	data := f.Value
+
+	if f.spec.Pad != nil {
+		data = f.spec.Pad.Pad(data, f.spec.Length)
+	}
+
+	packedValue, err := f.spec.Enc.Encode(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode content: %w", err)
+	}
+
+	packed := packedValue
+
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %w", err)
+	}
+
+	packed = append(packedLength, packed...)
+
+	tagBytes := []byte(f.spec.Tag.Tag)
+	if f.spec.Tag.Pad != nil {
+		tagBytes = f.spec.Tag.Pad.Pad(tagBytes, f.spec.Tag.Length)
+	}
+
+	tagBytes, err = f.spec.Tag.Enc.Encode(tagBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert subfield Tag \"%v\" to int", tagBytes)
+	}
+
+	packed = append(tagBytes, packed...)
+
+	return packed, nil
+}
+
+// Unpack do decode tlv field with encoded raw data (Tag + Length + Value)
+func (f *PrimitiveTLV) Unpack(data []byte) (int, error) {
+
+	if f.spec.Tag == nil || f.spec.Tag.Enc == nil || f.spec.Pref == nil || f.spec.Enc == nil {
+		return 0, fmt.Errorf("failed to unpack tlv: invalid spec")
+	}
+
+	offset := 0
+
+	// 1. Read Tag
+
+	tagBytes, read, err := f.spec.Tag.Enc.Decode(data[offset:], f.spec.Tag.Length)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unpack subfield Tag: %w", err)
+	}
+	offset += read
+
+	if f.spec.Tag.Pad != nil {
+		tagBytes = f.spec.Tag.Pad.Unpad(tagBytes)
+	}
+	tag := string(tagBytes)
+
+	if tag != f.spec.Tag.Tag {
+		return 0, fmt.Errorf("tag mismatch: want to read %s, got %s", f.spec.Tag.Tag, tag)
+	}
+
+	// 2. Read Length
+
+	dataLen, read, err := f.spec.Pref.DecodeLength(f.spec.Length, data[offset:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %w", err)
+	}
+	offset += read
+
+	// 3. Read Value
+
+	raw, read, err := f.spec.Enc.Decode(data[offset:], dataLen)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode content: %w", err)
+	}
+
+	if f.spec.Pad != nil {
+		raw = f.spec.Pad.Unpad(raw)
+	}
+
+	if err := f.SetBytes(raw); err != nil {
+		return 0, fmt.Errorf("failed to set bytes: %w", err)
+	}
+
+	return read + offset, nil
+}
+
+func (f *PrimitiveTLV) SetData(data interface{}) error {
+	if data == nil {
+		return nil
+	}
+
+	tlv, ok := data.(*PrimitiveTLV)
+	if !ok {
+		return fmt.Errorf("data does not match required *String type")
+	}
+
+	f.data = tlv
+	if len(tlv.Value) > 0 {
+		f.Value = tlv.Value
+	}
+	return nil
+}
+
+func (f *PrimitiveTLV) Marshal(data interface{}) error {
+	return f.SetData(data)
+}
+
+func (f *PrimitiveTLV) Unmarshal(v interface{}) error {
+	if v == nil {
+		return nil
+	}
+
+	tlv, ok := v.(*PrimitiveTLV)
+	if !ok {
+		return errors.New("data does not match required *PrimitiveTLV type")
+	}
+
+	tlv.Value = f.Value
+
+	return nil
+}
+
+func (f *PrimitiveTLV) MarshalJSON() ([]byte, error) {
+	str, err := f.String()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(str)
+}
+
+func (f *PrimitiveTLV) UnmarshalJSON(b []byte) error {
+	var v string
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return fmt.Errorf("failed to JSON unmarshal bytes to string: %w", err)
+	}
+
+	hex, err := encoding.ASCIIHexToBytes.Encode([]byte(v))
+	if err != nil {
+		return fmt.Errorf("failed to convert ASCII Hex string to bytes")
+	}
+	return f.SetBytes(hex)
+}

--- a/field/primitive_tlv_test.go
+++ b/field/primitive_tlv_test.go
@@ -1,0 +1,185 @@
+package field
+
+import (
+	"github.com/moov-io/iso8583/sort"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/padding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrimitiveTLVField(t *testing.T) {
+	spec := &Spec{
+		Length:      6,
+		Description: "Amount, Authorised",
+		Enc:         encoding.ASCII,
+		Pref:        prefix.BerTLV,
+		Pad:         padding.Left(' '),
+		Tag: &TagSpec{
+			Tag:  "9F02",
+			Enc:  encoding.BerTLVTag,
+			Sort: sort.StringsByHex,
+		},
+	}
+	tlv := NewPrimitiveTLV(spec)
+
+	sampleValue := []byte{0x0, 0x0, 0x0, 0x0, 0x63, 0x0}
+	sample := []byte{0x9f, 0x2, 0x6, 0x0, 0x0, 0x0, 0x0, 0x63, 0x0}
+
+	tlv.SetBytes(sampleValue)
+	require.Equal(t, sampleValue, tlv.Value)
+
+	packed, err := tlv.Pack()
+	require.NoError(t, err)
+	require.Equal(t, sample, packed)
+
+	length, err := tlv.Unpack(sample)
+	require.NoError(t, err)
+	require.Equal(t, 9, length)
+
+	b, err := tlv.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, sampleValue, b)
+
+	require.Equal(t, sampleValue, tlv.Value)
+
+	tlv = NewPrimitiveTLV(spec)
+	tlv.SetData(NewPrimitiveTLVValue(sampleValue))
+	packed, err = tlv.Pack()
+	require.NoError(t, err)
+	require.Equal(t, sample, packed)
+
+	tlv = NewPrimitiveTLV(spec)
+	data := NewPrimitiveTLVValue(nil)
+	tlv.SetData(data)
+	length, err = tlv.Unpack(sample)
+	require.NoError(t, err)
+	require.Equal(t, 9, length)
+	require.Equal(t, sampleValue, data.Value)
+
+	tlv = NewPrimitiveTLV(spec)
+	data = &PrimitiveTLV{}
+	tlv.SetData(data)
+	err = tlv.SetBytes(sampleValue)
+	require.NoError(t, err)
+	require.Equal(t, sampleValue, data.Value)
+
+	sampleWithUnmatchedTag := []byte{0x9f, 0x3, 0x6, 0x0, 0x0, 0x0, 0x0, 0x63, 0x0}
+
+	tlv = NewPrimitiveTLV(spec)
+	length, err = tlv.Unpack(sampleWithUnmatchedTag)
+	require.Error(t, err)
+	require.Equal(t, "tag mismatch: want to read 9F02, got 9F03", err.Error())
+
+}
+
+func TestPrimitiveTLVPack(t *testing.T) {
+	t.Run("pack with null value", func(t *testing.T) {
+		spec := &Spec{
+			Length:      6,
+			Description: "Amount, Authorised",
+			Enc:         encoding.ASCII,
+			Pref:        prefix.BerTLV,
+			Tag: &TagSpec{
+				Tag:  "9F02",
+				Enc:  encoding.BerTLVTag,
+				Sort: sort.StringsByHex,
+			},
+		}
+		tlv := NewPrimitiveTLV(spec)
+		pack, err := tlv.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x9f, 0x02, 0x00}, pack)
+	})
+
+	t.Run("pack with null value and padding", func(t *testing.T) {
+		spec := &Spec{
+			Length:      6,
+			Description: "Amount, Authorised",
+			Enc:         encoding.ASCII,
+			Pref:        prefix.BerTLV,
+			Pad:         padding.Left(0),
+			Tag: &TagSpec{
+				Tag:  "9F02",
+				Enc:  encoding.BerTLVTag,
+				Sort: sort.StringsByHex,
+			},
+		}
+		tlv := NewPrimitiveTLV(spec)
+		pack, err := tlv.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x9f, 0x2, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, pack)
+	})
+
+	t.Run("pack with hex string", func(t *testing.T) {
+		spec := &Spec{
+			Length:      6,
+			Description: "Amount, Authorised",
+			Enc:         encoding.Binary,
+			Pref:        prefix.BerTLV,
+			Tag: &TagSpec{
+				Tag:  "9F02",
+				Enc:  encoding.BerTLVTag,
+				Sort: sort.StringsByHex,
+			},
+		}
+
+		tlv := NewPrimitiveTLVHexString("9FA813")
+		tlv.SetSpec(spec)
+
+		pack, err := tlv.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x9f, 0x2, 0x3, 0x9f, 0xa8, 0x13}, pack)
+	})
+}
+
+func TestPrimitiveTLVFieldUnmarshal(t *testing.T) {
+
+	input := []byte{0x0, 0x0, 0x0, 0x0, 0x63, 0x0}
+
+	tlv := NewPrimitiveTLVValue(input)
+
+	val := &PrimitiveTLV{}
+
+	err := tlv.Unmarshal(val)
+
+	require.NoError(t, err)
+
+	require.Equal(t, input, val.Value)
+}
+
+func TestPrimitiveTLVJSONUnmarshal(t *testing.T) {
+	input := []byte(`"000000006300"`)
+
+	str := NewPrimitiveTLV(&Spec{
+		Length:      6,
+		Description: "Amount, Authorised",
+		Enc:         encoding.ASCII,
+		Pref:        prefix.BerTLV,
+		Tag: &TagSpec{
+			Tag:  "9F02",
+			Enc:  encoding.BerTLVTag,
+			Sort: sort.StringsByHex,
+		},
+	})
+
+	require.NoError(t, str.UnmarshalJSON(input))
+	require.Equal(t, []byte{0x0, 0x0, 0x0, 0x0, 0x63, 0x0}, str.Value)
+}
+
+func TestPrimitiveTLVJSONMarshal(t *testing.T) {
+
+	input := []byte{0x0, 0x0, 0x0, 0x0, 0x63, 0x0}
+
+	str := NewPrimitiveTLVValue(input)
+
+	marshalledJSON, err := str.MarshalJSON()
+
+	require.NoError(t, err)
+	require.Equal(t, `"000000006300"`, string(marshalledJSON))
+}

--- a/field/primitive_tlv_test.go
+++ b/field/primitive_tlv_test.go
@@ -71,6 +71,7 @@ func TestPrimitiveTLVField(t *testing.T) {
 	tlv = NewPrimitiveTLV(spec)
 	length, err = tlv.Unpack(sampleWithUnmatchedTag)
 	require.Error(t, err)
+	require.Equal(t, 0, length)
 	require.Equal(t, "tag mismatch: want to read 9F02, got 9F03", err.Error())
 
 }

--- a/field/spec.go
+++ b/field/spec.go
@@ -20,6 +20,9 @@ type TagSpec struct {
 	// This field should not be populated in conjunction with the TLV Tag
 	// encoder as their lengths are determined dynamically.
 	Length int
+	// Tag is an identifier to specify data field. ASCII Hex-digits
+	// The field use for tlv only
+	Tag string
 	// Enc defines the encoder used to marshal and unmarshal
 	// the tag.
 	Enc encoding.Encoder

--- a/prefix/bertlv_test.go
+++ b/prefix/bertlv_test.go
@@ -16,6 +16,7 @@ func TestBerTLVPrefixer(t *testing.T) {
 		{"single byte prefix", 1, 126, []byte{0b01111110}},
 		{"two byte prefix", 2, 131, []byte{0b10000001, 0b10000011}},
 		{"three byte prefix", 3, 65039, []byte{0b10000010, 0b11111110, 0b00001111}},
+		{"single byte prefix with zero", 1, 0, []byte{0b00000000}},
 	}
 
 	// test encoding


### PR DESCRIPTION
Created new 3 fields
- EMV, ConstructedTLV, PrimitiveTLV
Used existed pref and env
- BerTLV, BerTLVTag