### PR TITLE
fix go 1.19 formatting

### DIFF
--- a/cmd/iso8583/describe.go
+++ b/cmd/iso8583/describe.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/moov-io/iso8583"
@@ -59,7 +59,7 @@ func createMessageFromFile(path string, spec *iso8583.MessageSpec) (*iso8583.Mes
 	}
 	defer fd.Close()
 
-	raw, err := ioutil.ReadAll(fd)
+	raw, err := io.ReadAll(fd)
 	if err != nil {
 		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}
@@ -80,7 +80,7 @@ func createSpecFromFile(path string) (*iso8583.MessageSpec, error) {
 	}
 	defer fd.Close()
 
-	raw, err := ioutil.ReadAll(fd)
+	raw, err := io.ReadAll(fd)
 	if err != nil {
 		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}

--- a/encoding/bertlv.go
+++ b/encoding/bertlv.go
@@ -22,10 +22,10 @@ func (berTLVEncoderTag) Encode(data []byte) ([]byte, error) {
 // Decode converts hexadecimal TLV bytes into their ASCII representation according
 // to the following rules:
 //
-// 1) If bits 5 - 1 of the tag's first byte are all set, then we must read
-//    the subsequent byte for the tag number.
-// 2) We must continue reading subsequent bytes until we arrive at one whose
-//    most significant bit is unset.
+//  1. If bits 5 - 1 of the tag's first byte are all set, then we must read
+//     the subsequent byte for the tag number.
+//  2. We must continue reading subsequent bytes until we arrive at one whose
+//     most significant bit is unset.
 //
 // On success, the ASCII representation of the Tag is returned along with the
 // number of bytes read e.g. []byte{0x5F, 0x2A} would be converted to

--- a/field/composite.go
+++ b/field/composite.go
@@ -178,13 +178,12 @@ func (f *Composite) SetData(v interface{}) error {
 //
 // A valid input is as follows:
 //
-//      type CompositeData struct {
-//          F1 *String
-//          F2 *String
-//          F3 *Numeric
-//          F4 *SubfieldCompositeData
-//      }
-//
+//	type CompositeData struct {
+//	    F1 *String
+//	    F2 *String
+//	    F3 *Numeric
+//	    F4 *SubfieldCompositeData
+//	}
 func (f *Composite) Marshal(v interface{}) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {

--- a/specs/builder_test.go
+++ b/specs/builder_test.go
@@ -1,7 +1,7 @@
 package specs
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestBuilder(t *testing.T) {
 }
 
 func TestExampleJSONSpec(t *testing.T) {
-	asciiJson, err := ioutil.ReadFile("../examples/specs/spec87ascii.json")
+	asciiJson, err := os.ReadFile("../examples/specs/spec87ascii.json")
 	require.NoError(t, err)
 
 	asciiSpec, err := Builder.ImportJSON(asciiJson)

--- a/test/fuzz-reader/reader_test.go
+++ b/test/fuzz-reader/reader_test.go
@@ -18,7 +18,6 @@
 package fuzzreader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -35,7 +34,7 @@ func TestCorpusSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip()
 	}
-	fds, err := ioutil.ReadDir("corpus")
+	fds, err := os.ReadDir("corpus")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +43,7 @@ func TestCorpusSymlinks(t *testing.T) {
 	}
 
 	for i := range fds {
-		if fds[i].Mode()&os.ModeSymlink != 0 {
+		if fds[i].Type()&os.ModeSymlink != 0 {
 			if path, err := os.Readlink(filepath.Join("corpus", fds[i].Name())); err != nil {
 				t.Errorf("broken symlink: %v", err)
 			} else {
@@ -60,7 +59,7 @@ func TestCorpusSymlinks(t *testing.T) {
 
 func TestFuzzWithValidData(t *testing.T) {
 
-	byteData, err := ioutil.ReadFile(filepath.Join("..", "..", "test", "testdata", "financial_transaction_message.dat"))
+	byteData, err := os.ReadFile(filepath.Join("..", "..", "test", "testdata", "financial_transaction_message.dat"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +68,7 @@ func TestFuzzWithValidData(t *testing.T) {
 		t.Errorf("Expected value is 1 (got %v)", ret)
 	}
 
-	byteData, err = ioutil.ReadFile(filepath.Join(basePath, "..", "testdata", "iso_reversal_message_error_date.dat"))
+	byteData, err = os.ReadFile(filepath.Join(basePath, "..", "testdata", "iso_reversal_message_error_date.dat"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
What:
* `go fmt` two files as go 1.19 has changed how it formats comments and we have a linter that tells us we have to re-format some files