### PR TITLE
add SetValue() method to binary, string, numeric fields

### DIFF
--- a/field/binary.go
+++ b/field/binary.go
@@ -68,6 +68,10 @@ func (f *Binary) Value() []byte {
 	return f.value
 }
 
+func (f *Binary) SetValue(v []byte) {
+	f.value = v
+}
+
 func (f *Binary) Pack() ([]byte, error) {
 	data := f.value
 

--- a/field/binary_test.go
+++ b/field/binary_test.go
@@ -79,6 +79,14 @@ func TestBinaryField(t *testing.T) {
 		require.Equal(t, in, data.value)
 	})
 
+	// SetValue sets data to the data field
+	t.Run("SetValue sets data to the data field", func(t *testing.T) {
+		bin := NewBinary(spec)
+		bin.SetValue(in)
+
+		require.Equal(t, in, bin.Value())
+	})
+
 	t.Run("Unpack sets data to data value", func(t *testing.T) {
 		bin := NewBinary(spec)
 		data := NewBinaryValue([]byte{})

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -81,6 +81,10 @@ func (f *Numeric) Value() int {
 	return f.value
 }
 
+func (f *Numeric) SetValue(v int) {
+	f.value = v
+}
+
 func (f *Numeric) Pack() ([]byte, error) {
 	data := []byte(strconv.Itoa(f.value))
 

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -49,6 +49,11 @@ func TestNumericField(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 10, length)
 	require.Equal(t, 9876, data.Value())
+
+	numeric = NewNumeric(spec)
+	numeric.SetValue(9876)
+
+	require.Equal(t, 9876, numeric.Value())
 }
 
 func TestNumericNil(t *testing.T) {

--- a/field/string.go
+++ b/field/string.go
@@ -67,6 +67,10 @@ func (f *String) Value() string {
 	return f.value
 }
 
+func (f *String) SetValue(v string) {
+	f.value = v
+}
+
 func (f *String) Pack() ([]byte, error) {
 	data := []byte(f.value)
 

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -57,6 +57,10 @@ func TestStringField(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello", data.Value())
 
+	str = NewString(spec)
+
+	str.SetValue("hello")
+	require.Equal(t, "hello", data.Value())
 }
 
 func TestStringNil(t *testing.T) {


### PR DESCRIPTION
Before we introduced `Value()` method, we used `Value` to get and set values. This PR adds a missing setter.