### PR TITLE
Fix binaryVarPrefixer to work with more bytes than prefix

### DIFF
--- a/prefix/binary.go
+++ b/prefix/binary.go
@@ -93,15 +93,17 @@ func (p *binaryVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, err
 		return 0, 0, fmt.Errorf("not enough data length: %d to read: %d bytes", len(data), p.Digits)
 	}
 
+	prefBytes := data[:p.Digits]
+
 	// it take 4 bytes to encode (u)int32
 	uint32Size := 4
 
 	// prepend with 0x00 if len of data is less than intSize (4 bytes)
-	if len(data) < uint32Size {
-		data = append(bytes.Repeat([]byte{0x00}, uint32Size-len(data)), data...)
+	if len(prefBytes) < uint32Size {
+		prefBytes = append(bytes.Repeat([]byte{0x00}, uint32Size-len(prefBytes)), prefBytes...)
 	}
 
-	dataLen, err := bytesToInt(data)
+	dataLen, err := bytesToInt(prefBytes)
 	if err != nil {
 		return 0, 0, fmt.Errorf("decode length: %w", err)
 	}

--- a/prefix/binary_test.go
+++ b/prefix/binary_test.go
@@ -153,6 +153,19 @@ func Test_binaryVarPrefixer_DecodeLength(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name: "success(L)_withMoreData",
+			fields: fields{
+				Digits: 1,
+			},
+			args: args{
+				maxLen: 32,
+				data:   []byte{0x18, 0x0, 0x0, 0x0},
+			},
+			wantDataLen: 24,
+			wantRead:    1,
+			wantErr:     false,
+		},
+		{
 			name: "success(LLL)",
 			fields: fields{
 				Digits: 3,
@@ -160,6 +173,19 @@ func Test_binaryVarPrefixer_DecodeLength(t *testing.T) {
 			args: args{
 				maxLen: 19999999,
 				data:   []byte{0xab, 0xcb, 0xff},
+			},
+			wantDataLen: 11258879,
+			wantRead:    3,
+			wantErr:     false,
+		},
+		{
+			name: "success(LLL)_withMoreData",
+			fields: fields{
+				Digits: 3,
+			},
+			args: args{
+				maxLen: 19999999,
+				data:   []byte{0xab, 0xcb, 0xff, 0x0, 0x0, 0x0},
 			},
 			wantDataLen: 11258879,
 			wantRead:    3,


### PR DESCRIPTION
Adjusts the length decoding, the previous implementation only works when the data provided only has the length bytes, being the real case scenario when data always haves more data than the prefix bytes.

To adjust this issue was necessary to cut the amount of bytes corresponding to the digits attribute from the data provided.