### PR TITLE
Add flag to skip unexpected TLV tags

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
 	"reflect"
 	"regexp"
 
@@ -325,7 +327,7 @@ func (f *Composite) UnmarshalJSON(b []byte) error {
 	}
 
 	for tag, rawMsg := range data {
-		if _, ok := f.spec.Subfields[tag]; !ok {
+		if _, ok := f.spec.Subfields[tag]; !ok && !skipUnknownTLVTags(f) {
 			return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
 		}
 
@@ -424,12 +426,20 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, error) {
 			tagBytes = f.spec.Tag.Pad.Unpad(tagBytes)
 		}
 		tag := string(tagBytes)
-		if _, ok := f.spec.Subfields[tag]; !ok {
+		if _, ok := f.spec.Subfields[tag]; !ok && !skipUnknownTLVTags(f) {
 			return 0, fmt.Errorf("failed to unpack subfield %v: field not defined in Spec", tag)
 		}
 
 		field, ok := f.subfields[tag]
 		if !ok {
+			// Obtain the length of the unknown tag and add it to the offset.
+			if skipUnknownTLVTags(f) {
+				fieldLength, readed, err := prefix.BerTLV.DecodeLength(999, data[offset:])
+				if err != nil {
+					return 0, err
+				}
+				offset += fieldLength + readed
+			}
 			continue
 		}
 
@@ -490,4 +500,8 @@ func getFieldIndexOrTag(field reflect.StructField) (string, error) {
 	}
 
 	return "", nil
+}
+
+func skipUnknownTLVTags(field *Composite) bool {
+	return field.spec.Tag != nil && field.spec.Tag.SkipUnknownTLVTags && field.spec.Tag.Enc == encoding.BerTLVTag
 }

--- a/field/composite.go
+++ b/field/composite.go
@@ -413,6 +413,10 @@ func (f *Composite) unpackSubfields(data []byte, isVariableLength bool) (int, er
 	return offset, nil
 }
 
+// ignoredMaxLen is a constant meant to be used in encoders that don't use the maxLength argument during
+// length decoding.
+const ignoredMaxLen int = 0
+
 func (f *Composite) unpackSubfieldsByTag(data []byte) (int, error) {
 	offset := 0
 	for offset < len(data) {
@@ -430,7 +434,6 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, error) {
 			if f.skipUnknownTLVTags() {
 				// Obtain the length of the unknown tag and add it to the offset.
 				// Because BER-TLV lengths are decoded dynamically, the maxLen method argument is ignored.
-				const ignoredMaxLen int = 0
 				fieldLength, readed, err := prefix.BerTLV.DecodeLength(ignoredMaxLen, data[offset:])
 				if err != nil {
 					return 0, err

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -342,9 +342,11 @@ func TestTLVPacking(t *testing.T) {
 			tlvTestSpec.Tag.SkipUnknownTLVTags = false
 		}()
 
+		// The field's specification contains the tags 9A and 9F02
 		composite := NewComposite(tlvTestSpec)
 
-		// Data contains tags 9F36, 9A, 9F02 and 9F37
+		// This data contains tags 9A and 9F02 that are mapped in the specification, but also
+		// contains tags 9F36 and 9F37 which aren't in the specification.
 		read, err := composite.Unpack([]byte{0x30, 0x32, 0x36, 0x9f, 0x36, 0x2, 0x1, 0x57, 0x9a, 0x3, 0x21, 0x7, 0x20,
 			0x9f, 0x2, 0x6, 0x0, 0x0, 0x0, 0x0, 0x5, 0x1, 0x9f, 0x37, 0x4, 0x9b, 0xad, 0xbc, 0xab})
 		require.NoError(t, err)
@@ -425,7 +427,8 @@ func TestTLVPacking(t *testing.T) {
 	t.Run("Unpack throws an error due unexpected tags", func(t *testing.T) {
 		composite := NewComposite(tlvTestSpec)
 
-		// Data contains tags 9F36, 9A, 9F02 and 9F37
+		// This data contains tags 9A and 9F02 that are mapped in the specification, but also
+		// contains tags 9F36 and 9F37 which aren't in the specification.
 		_, err := composite.Unpack([]byte{0x30, 0x32, 0x36, 0x9f, 0x36, 0x2, 0x1, 0x57, 0x9a, 0x3, 0x21, 0x7, 0x20,
 			0x9f, 0x2, 0x6, 0x0, 0x0, 0x0, 0x0, 0x5, 0x1, 0x9f, 0x37, 0x4, 0x9b, 0xad, 0xbc, 0xab})
 		require.EqualError(t, err, "failed to unpack subfield 9F36: field not defined in Spec")
@@ -1172,7 +1175,10 @@ func TestTLVJSONConversion(t *testing.T) {
 		defer func() {
 			tlvTestSpec.Tag.SkipUnknownTLVTags = false
 		}()
-		json_extra_tags := `{"9A":"210720","9F02":"000000000501", "9F37": "9badbcab"}`
+
+		// This data contains tags 9A and 9F02 that are mapped in the specification, but also
+		// contains tag 9F37 which isn't in the specification.
+		json_tags := `{"9A":"210720","9F02":"000000000501", "9F37": "9badbcab"}`
 
 		data := &TLVTestData{}
 
@@ -1180,7 +1186,7 @@ func TestTLVJSONConversion(t *testing.T) {
 		err := composite.Marshal(data)
 		require.NoError(t, err)
 
-		require.NoError(t, composite.UnmarshalJSON([]byte(json_extra_tags)))
+		require.NoError(t, composite.UnmarshalJSON([]byte(json_tags)))
 
 		require.NoError(t, composite.Unmarshal(data))
 
@@ -1189,7 +1195,9 @@ func TestTLVJSONConversion(t *testing.T) {
 	})
 
 	t.Run("UnmarshalJSON TLV data throws an error due unexpected tags", func(t *testing.T) {
-		json_extra_tags := `{"9A":"210720","9F02":"000000000501", "9F37": "9badbcab"}`
+		// This data contains tags 9A and 9F02 that are mapped in the specification, but also
+		// contains tag 9F37 which isn't in the specification.
+		json_tags := `{"9A":"210720","9F02":"000000000501", "9F37": "9badbcab"}`
 
 		data := &TLVTestData{}
 
@@ -1197,7 +1205,7 @@ func TestTLVJSONConversion(t *testing.T) {
 		err := composite.Marshal(data)
 		require.NoError(t, err)
 
-		err = composite.UnmarshalJSON([]byte(json_extra_tags))
+		err = composite.UnmarshalJSON([]byte(json_tags))
 		require.Error(t, err)
 		require.EqualError(t, err, "failed to unmarshal subfield 9F37: received subfield not defined in spec")
 	})

--- a/field/spec.go
+++ b/field/spec.go
@@ -31,6 +31,11 @@ type TagSpec struct {
 	// spec must be packed. This ordering may also be used for unpacking
 	// if Spec.Tag.Enc == nil.
 	Sort sort.StringSlice
+	// SkipUnknownTLVTags is a flag which indicates whether TLV tags that are not found in
+	// the spec should be skipped and continue processing the field or throwing and error.
+	// By default, this flag is disabled and unexpected TLV tags will throw an error.
+	// This flag is only meant to be used in Composite fields with TLV encoding.
+	SkipUnknownTLVTags bool
 }
 
 // Spec defines the structure of a field.


### PR DESCRIPTION
This PR adds a flag `SkipUnknownTLVTags` in the tag specification to enable the skip of unknown tags in TLV-coded fields.
The current implementation throws an error when receives a tag that is not in the spec.

That tag will only work in conjunction with BerTLVTag encoding.
By default the flag is off, maintaining the current behavior. The users can activate it based on their needs.