### PR TITLE
fix for #220 bcd length encoding

### DIFF
--- a/encoding/ascii.go
+++ b/encoding/ascii.go
@@ -13,16 +13,16 @@ var (
 
 type asciiEncoder struct{}
 
-func (e asciiEncoder) Encode(data []byte) ([]byte, error) {
+func (e asciiEncoder) Encode(data []byte) ([]byte, int, error) {
 	var out []byte
 	for _, r := range data {
 		if r > 127 {
-			return nil, utils.NewSafeError(fmt.Errorf("invalid ASCII char: '%s'", string(r)), "failed to perform ASCII encoding")
+			return nil, 0, utils.NewSafeError(fmt.Errorf("invalid ASCII char: '%s'", string(r)), "failed to perform ASCII encoding")
 		}
 		out = append(out, r)
 	}
 
-	return out, nil
+	return out, len(out), nil
 }
 
 func (e asciiEncoder) Decode(data []byte, length int) ([]byte, int, error) {

--- a/encoding/ascii_test.go
+++ b/encoding/ascii_test.go
@@ -30,12 +30,12 @@ func TestASCII(t *testing.T) {
 	})
 
 	t.Run("Encode", func(t *testing.T) {
-		res, err := enc.Encode([]byte("hello"))
+		res, _, err := enc.Encode([]byte("hello"))
 
 		require.NoError(t, err)
 		require.Equal(t, []byte("hello"), res)
 
-		_, err = enc.Encode([]byte("hello, 世界!"))
+		_, _, err = enc.Encode([]byte("hello, 世界!"))
 		require.Error(t, err)
 		require.EqualError(t, err, "failed to perform ASCII encoding")
 	})

--- a/encoding/bcd.go
+++ b/encoding/bcd.go
@@ -14,7 +14,8 @@ var (
 
 type bcdEncoder struct{}
 
-func (e *bcdEncoder) Encode(src []byte) ([]byte, error) {
+func (e *bcdEncoder) Encode(src []byte) ([]byte, int, error) {
+	length := len(src)
 	if len(src)%2 != 0 {
 		src = append([]byte("0"), src...)
 	}
@@ -23,10 +24,10 @@ func (e *bcdEncoder) Encode(src []byte) ([]byte, error) {
 	dst := make([]byte, bcd.EncodedLen(len(src)))
 	n, err := enc.Encode(dst, src)
 	if err != nil {
-		return nil, utils.NewSafeError(err, "failed to perform BCD encoding")
+		return nil, 0, utils.NewSafeError(err, "failed to perform BCD encoding")
 	}
 
-	return dst[:n], nil
+	return dst[:n], length, nil
 }
 
 func (e *bcdEncoder) Decode(src []byte, length int) ([]byte, int, error) {

--- a/encoding/bcd_test.go
+++ b/encoding/bcd_test.go
@@ -54,16 +54,17 @@ func TestBCD(t *testing.T) {
 	})
 
 	t.Run("Encode", func(t *testing.T) {
-		res, err := BCD.Encode([]byte("0110"))
+		res, _, err := BCD.Encode([]byte("0110"))
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x01, 0x10}, res)
 
 		// right justified by default
-		res, err = BCD.Encode([]byte("123"))
+		res, length, err := BCD.Encode([]byte("123"))
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x01, 0x23}, res)
+		require.Equal(t, 3, length)
 
-		_, err = BCD.Encode([]byte("abc"))
+		_, _, err = BCD.Encode([]byte("abc"))
 		require.Error(t, err)
 		require.EqualError(t, err, "failed to perform BCD encoding")
 		require.ErrorIs(t, err, bcd.ErrBadInput)

--- a/encoding/bertlv.go
+++ b/encoding/bertlv.go
@@ -16,9 +16,8 @@ type berTLVEncoderTag struct{}
 
 // Encode converts ASCII Hex-digits into a byte slice e.g. []byte("AABBCC")
 // would be converted into []byte{0xAA, 0xBB, 0xCC}
-func (berTLVEncoderTag) Encode(data []byte) ([]byte, error) {
-	out, err := ASCIIHexToBytes.Encode(data)
-	return out, err
+func (berTLVEncoderTag) Encode(data []byte) ([]byte, int, error) {
+	return ASCIIHexToBytes.Encode(data)
 }
 
 // Decode converts hexadecimal TLV bytes into their ASCII representation according

--- a/encoding/bertlv_test.go
+++ b/encoding/bertlv_test.go
@@ -34,7 +34,7 @@ func TestBerTLVTag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc+"_Encode", func(t *testing.T) {
-			hexTag, err := BerTLVTag.Encode(tt.asciiTag)
+			hexTag, _, err := BerTLVTag.Encode(tt.asciiTag)
 			require.NoError(t, err)
 			require.Equal(t, tt.hexTag, hexTag)
 		})

--- a/encoding/binary.go
+++ b/encoding/binary.go
@@ -11,10 +11,10 @@ var (
 
 type binaryEncoder struct{}
 
-func (e binaryEncoder) Encode(data []byte) ([]byte, error) {
+func (e binaryEncoder) Encode(data []byte) ([]byte, int, error) {
 	out := append([]byte(nil), data...)
 
-	return out, nil
+	return out, len(out), nil
 }
 
 func (e binaryEncoder) Decode(data []byte, length int) ([]byte, int, error) {

--- a/encoding/ebcdic.go
+++ b/encoding/ebcdic.go
@@ -82,12 +82,12 @@ var (
 
 type ebcdicEncoder struct{}
 
-func (e *ebcdicEncoder) Encode(src []byte) ([]byte, error) {
+func (e *ebcdicEncoder) Encode(src []byte) ([]byte, int, error) {
 	var dst []byte
 	for _, v := range src {
 		dst = append(dst, asciiToEbcdic[v])
 	}
-	return dst, nil
+	return dst, len(dst), nil
 }
 
 func (e *ebcdicEncoder) Decode(src []byte, length int) ([]byte, int, error) {

--- a/encoding/ebcdic1047.go
+++ b/encoding/ebcdic1047.go
@@ -21,12 +21,12 @@ type ebcdic1047Encoder struct {
 	decoder *xencoding.Decoder
 }
 
-func (e ebcdic1047Encoder) Encode(data []byte) ([]byte, error) {
+func (e ebcdic1047Encoder) Encode(data []byte) ([]byte, int, error) {
 	bytes, err := e.encoder.Bytes(data)
 	if err != nil {
-		return nil, utils.NewSafeError(err, "failed to encode EBCDIC")
+		return nil, 0, utils.NewSafeError(err, "failed to encode EBCDIC")
 	}
-	return bytes, nil
+	return bytes, len(bytes), nil
 }
 
 func (e ebcdic1047Encoder) Decode(data []byte, length int) ([]byte, int, error) {

--- a/encoding/ebcdic1047_test.go
+++ b/encoding/ebcdic1047_test.go
@@ -220,7 +220,7 @@ var knownEncodings = []struct {
 func TestEBCDIC1047SingleCharacterEncode(t *testing.T) {
 	t.Parallel()
 	for character, expectedEncoding := range ebcdic1047CharacterEncodings {
-		encoding, err := EBCDIC1047.Encode([]byte(character))
+		encoding, _, err := EBCDIC1047.Encode([]byte(character))
 		require.NoError(t, err)
 		require.Len(t, encoding, 1)
 		require.Equal(t, expectedEncoding, encoding[0])
@@ -240,7 +240,7 @@ func TestEBCDIC1047SingleCharacterDecode(t *testing.T) {
 func TestEBCDIC1047Encode(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range knownEncodings {
-		encoding, err := EBCDIC1047.Encode([]byte(testCase.Phrase))
+		encoding, _, err := EBCDIC1047.Encode([]byte(testCase.Phrase))
 		require.NoError(t, err)
 		require.Equal(t, testCase.Encoding, encoding)
 	}

--- a/encoding/ebcdic_test.go
+++ b/encoding/ebcdic_test.go
@@ -25,7 +25,7 @@ func TestEBCDIC(t *testing.T) {
 	})
 
 	t.Run("Encode", func(t *testing.T) {
-		res, err := EBCDIC.Encode([]byte{0x12, 0x94})
+		res, _, err := EBCDIC.Encode([]byte{0x12, 0x94})
 
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x12, 0x34}, res)

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -1,7 +1,7 @@
 package encoding
 
 type Encoder interface {
-	Encode([]byte) ([]byte, error)
+	Encode([]byte) (packed []byte, length int, err error)
 	// Returns data decoded into ASCII (or bytes), how many bytes were read, error
 	Decode([]byte, int) (data []byte, read int, err error)
 }

--- a/encoding/hex.go
+++ b/encoding/hex.go
@@ -20,14 +20,14 @@ type hexToASCIIEncoder struct{}
 // Encode converts bytes into their ASCII representation.  On success, the
 // ASCII representation bytes are returned e.g. []byte{0x5F, 0x2A} would be
 // converted to []byte("5F2A")
-func (e hexToASCIIEncoder) Encode(data []byte) ([]byte, error) {
+func (e hexToASCIIEncoder) Encode(data []byte) ([]byte, int, error) {
 	out := make([]byte, hex.EncodedLen(len(data)))
 	hex.Encode(out, data)
 
 	str := string(out)
 	str = strings.ToUpper(str)
 
-	return []byte(str), nil
+	return []byte(str), len(str), nil
 }
 
 // Decodes ASCII hex and returns bytes
@@ -64,15 +64,15 @@ type asciiToHexEncoder struct{}
 
 // Encode converts ASCII Hex-digits into a byte slice e.g. []byte("AABBCC")
 // would be converted into []byte{0xAA, 0xBB, 0xCC}
-func (e asciiToHexEncoder) Encode(data []byte) ([]byte, error) {
+func (e asciiToHexEncoder) Encode(data []byte) ([]byte, int, error) {
 	out := make([]byte, hex.DecodedLen(len(data)))
 
 	_, err := hex.Decode(out, data)
 	if err != nil {
-		return nil, utils.NewSafeError(err, "failed to perform hex decoding")
+		return nil, 0, utils.NewSafeError(err, "failed to perform hex decoding")
 	}
 
-	return out, nil
+	return out, len(out), nil
 }
 
 // Decode converts bytes into their ASCII representation.

--- a/encoding/hex_test.go
+++ b/encoding/hex_test.go
@@ -22,7 +22,7 @@ func TestHexToASCIIEncoder(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "failed to perform hex decoding")
 
-	got, err = enc.Encode([]byte{0xAA, 0xBB, 0xCC})
+	got, _, err = enc.Encode([]byte{0xAA, 0xBB, 0xCC})
 	require.NoError(t, err)
 	require.Equal(t, []byte("AABBCC"), got)
 }
@@ -35,11 +35,11 @@ func TestASCIIToHexEncoder(t *testing.T) {
 	require.Equal(t, []byte("AABBCC"), got)
 	require.Equal(t, 3, read)
 
-	got, err = enc.Encode([]byte("aabbcc"))
+	got, _, err = enc.Encode([]byte("aabbcc"))
 	require.NoError(t, err)
 	require.Equal(t, []byte{0xAA, 0xBB, 0xCC}, got)
 
-	_, err = enc.Encode([]byte("nothex"))
+	_, _, err = enc.Encode([]byte("nothex"))
 	require.Error(t, err)
 	require.EqualError(t, err, "failed to perform hex decoding")
 }

--- a/encoding/lbcd.go
+++ b/encoding/lbcd.go
@@ -14,7 +14,8 @@ var (
 
 type lBCDEncoder struct{}
 
-func (e *lBCDEncoder) Encode(src []byte) ([]byte, error) {
+func (e *lBCDEncoder) Encode(src []byte) ([]byte, int, error) {
+	length := len(src)
 	if len(src)%2 != 0 {
 		src = append(src, []byte("0")...)
 	}
@@ -23,10 +24,10 @@ func (e *lBCDEncoder) Encode(src []byte) ([]byte, error) {
 	dst := make([]byte, bcd.EncodedLen(len(src)))
 	n, err := enc.Encode(dst, src)
 	if err != nil {
-		return nil, utils.NewSafeError(err, "failed to perform BCD encoding")
+		return nil, 0, utils.NewSafeError(err, "failed to perform BCD encoding")
 	}
 
-	return dst[:n], nil
+	return dst[:n], length, nil
 }
 
 func (e *lBCDEncoder) Decode(src []byte, length int) ([]byte, int, error) {

--- a/encoding/lbcd_test.go
+++ b/encoding/lbcd_test.go
@@ -36,11 +36,12 @@ func TestLBCD(t *testing.T) {
 	})
 
 	t.Run("Encode", func(t *testing.T) {
-		res, err := LBCD.Encode([]byte("123"))
+		res, encLength, err := LBCD.Encode([]byte("123"))
 		require.NoError(t, err)
 		require.Equal(t, []byte{0x12, 0x30}, res)
+		require.Equal(t, 3, encLength)
 
-		_, err = LBCD.Encode([]byte("abc"))
+		_, _, err = LBCD.Encode([]byte("abc"))
 		require.Error(t, err)
 		require.EqualError(t, err, "failed to perform BCD encoding")
 		require.ErrorIs(t, err, bcd.ErrBadInput)

--- a/field/binary.go
+++ b/field/binary.go
@@ -79,12 +79,12 @@ func (f *Binary) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
@@ -169,7 +169,7 @@ func (f *Binary) UnmarshalJSON(b []byte) error {
 		return utils.NewSafeError(err, "failed to JSON unmarshal bytes to string")
 	}
 
-	hex, err := encoding.ASCIIHexToBytes.Encode([]byte(v))
+	hex, _, err := encoding.ASCIIHexToBytes.Encode([]byte(v))
 	if err != nil {
 		return utils.NewSafeError(err, "failed to convert ASCII Hex string to bytes")
 	}

--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -66,7 +66,7 @@ func (f *Bitmap) String() (string, error) {
 }
 
 func (f *Bitmap) Pack() ([]byte, error) {
-	packed, err := f.spec.Enc.Encode(f.data)
+	packed, _, err := f.spec.Enc.Encode(f.data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}

--- a/field/composite.go
+++ b/field/composite.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/moov-io/iso8583/encoding"
-	"github.com/moov-io/iso8583/prefix"
 	"reflect"
 	"regexp"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
 
 	"github.com/moov-io/iso8583/padding"
 	"github.com/moov-io/iso8583/sort"
@@ -363,7 +364,7 @@ func (f *Composite) pack() ([]byte, error) {
 			if f.spec.Tag.Pad != nil {
 				tagBytes = f.spec.Tag.Pad.Pad(tagBytes, f.spec.Tag.Length)
 			}
-			tagBytes, err := f.spec.Tag.Enc.Encode(tagBytes)
+			tagBytes, _, err := f.spec.Tag.Enc.Encode(tagBytes)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert subfield Tag \"%v\" to int", tagBytes)
 			}

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -92,12 +92,12 @@ func (f *Numeric) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/string.go
+++ b/field/string.go
@@ -78,12 +78,12 @@ func (f *String) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encodedLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encodedLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/track1.go
+++ b/field/track1.go
@@ -72,12 +72,12 @@ func (f *Track1) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/track2.go
+++ b/field/track2.go
@@ -71,12 +71,12 @@ func (f *Track2) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/track3.go
+++ b/field/track3.go
@@ -69,12 +69,12 @@ func (f *Track3) Pack() ([]byte, error) {
 		data = f.spec.Pad.Pad(data, f.spec.Length)
 	}
 
-	packed, err := f.spec.Enc.Encode(data)
+	packed, encLength, err := f.spec.Enc.Encode(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, encLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/network/bcd_2bytes.go
+++ b/network/bcd_2bytes.go
@@ -29,7 +29,7 @@ func (h *BCD2BytesHeader) Length() int {
 
 func (h *BCD2BytesHeader) WriteTo(w io.Writer) (int, error) {
 	strLen := fmt.Sprintf("%04d", h.Len)
-	res, err := encoding.BCD.Encode([]byte(strLen))
+	res, _, err := encoding.BCD.Encode([]byte(strLen))
 	if err != nil {
 		return 0, err
 	}

--- a/prefix/bcd.go
+++ b/prefix/bcd.go
@@ -31,7 +31,7 @@ func (p *bcdVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.Digits, dataLen)
-	res, err := encoding.BCD.Encode([]byte(strLen))
+	res, _, err := encoding.BCD.Encode([]byte(strLen))
 	if err != nil {
 		return nil, err
 	}

--- a/prefix/ebcdic.go
+++ b/prefix/ebcdic.go
@@ -30,7 +30,7 @@ func (p *ebcdicVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.Digits, dataLen)
-	res, err := encoding.EBCDIC.Encode([]byte(strLen))
+	res, _, err := encoding.EBCDIC.Encode([]byte(strLen))
 	if err != nil {
 		return nil, err
 	}

--- a/prefix/ebcdic1047.go
+++ b/prefix/ebcdic1047.go
@@ -30,7 +30,7 @@ func (p *ebcdic1047Prefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.digits, dataLen)
-	res, err := encoding.EBCDIC1047.Encode([]byte(strLen))
+	res, _, err := encoding.EBCDIC1047.Encode([]byte(strLen))
 	if err != nil {
 		return nil, err
 	}

--- a/sort/strings.go
+++ b/sort/strings.go
@@ -39,11 +39,11 @@ func StringsByInt(x []string) {
 // of even length.
 func StringsByHex(x []string) {
 	sort.Slice(x, func(i, j int) bool {
-		valI, err := encoding.ASCIIHexToBytes.Encode([]byte(x[i]))
+		valI, _, err := encoding.ASCIIHexToBytes.Encode([]byte(x[i]))
 		if err != nil {
 			panic(fmt.Sprintf("failed to encode ascii hex %s to bytes : %v", x[i], err))
 		}
-		valJ, err := encoding.ASCIIHexToBytes.Encode([]byte(x[j]))
+		valJ, _, err := encoding.ASCIIHexToBytes.Encode([]byte(x[j]))
 		if err != nil {
 			panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
 		}


### PR DESCRIPTION
Here's is my proposition for fixing the bcd length encoding. This also fixes the variable encoding where an odd length was encoded with the next even number.

The problem I had with bcd is that there is no way to find out whether the length of original data was odd or even, that's why the `Encoder interface, Encode` return type change.

I couldn't come up with a more elegant solution.
