### PR TITLE
Fuzzer reports me that length should be positive

### DIFF
--- a/prefix/ascii.go
+++ b/prefix/ascii.go
@@ -42,6 +42,11 @@ func (p *asciiVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, erro
 		return 0, 0, err
 	}
 
+	// length should be positive
+	if dataLen < 0 {
+		return 0, 0, fmt.Errorf("invalid length: %d", dataLen)
+	}
+
 	if dataLen > maxLen {
 		return 0, 0, fmt.Errorf("data length: %d is larger than maximum %d", dataLen, maxLen)
 	}


### PR DESCRIPTION
with:

```
panic: runtime error: slice bounds out of range [:-7]
            goroutine 46 [running]:
            runtime/debug.Stack()
                runtime/debug/stack.go:24 +0x9e
            testing.tRunner.func1()
                testing/testing.go:1485 +0x1f6
            panic({0x105b620, 0xc00003e300})
                runtime/panic.go:884 +0x213
            github.com/moov-io/iso8583/field.(*Composite).Unpack(0xc00044e660, {0xc000044377, 0x3, 0x9})
                github.com/moov-io/iso8583@v0.15.3/field/composite.go:271 +0x40a
            github.com/moov-io/iso8583.(*Message).Unpack(0xc000456780, {0xc000044300, 0x7a, 0x80})
                github.com/moov-io/iso8583@v0.15.3/message.go:196 +0x5d8
```