### PR TITLE
use length of the field value for prefixer, not length of encoded data

### DIFF
--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -1,7 +1,12 @@
 package encoding
 
 type Encoder interface {
+	// Encode encodes source data (ASCII, characters, digits, etc.) into
+	// destination bytes. It returns encoded bytes and any error
 	Encode([]byte) ([]byte, error)
-	// Returns data decoded into ASCII (or bytes), how many bytes were read, error
+
+	// Decode decodes data into into bytes (ASCII, characters, digits,
+	// etc.). It returns the bytes representing the decoded data, the
+	// number of bytes read from the input, and any error
 	Decode([]byte, int) (data []byte, read int, err error)
 }

--- a/field/binary.go
+++ b/field/binary.go
@@ -84,7 +84,7 @@ func (f *Binary) Pack() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/composite.go
+++ b/field/composite.go
@@ -26,6 +26,9 @@ var _ json.Unmarshaler = (*Composite)(nil)
 // documentation and error messages. These subfields are defined using the
 // 'Subfields' field on the field.Spec struct.
 //
+// Because composite subfields may be encoded with different encodings, the
+// Length field on the field.Spec struct is in bytes.
+//
 // Composite handles aggregate fields of the following format:
 // - Length (if variable)
 // - []Subfield

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -235,12 +235,12 @@ var (
 		Subfields: map[string]Field{
 			"9A": NewHex(&Spec{
 				Description: "Transaction Date",
-				Enc:         encoding.ASCIIHexToBytes,
+				Enc:         encoding.Binary,
 				Pref:        prefix.BerTLV,
 			}),
 			"9F02": NewHex(&Spec{
 				Description: "Amount, Authorized (Numeric)",
-				Enc:         encoding.ASCIIHexToBytes,
+				Enc:         encoding.Binary,
 				Pref:        prefix.BerTLV,
 			}),
 		},
@@ -257,12 +257,12 @@ var (
 		Subfields: map[string]Field{
 			"82": NewHex(&Spec{
 				Description: "Application Interchange Profile",
-				Enc:         encoding.ASCIIHexToBytes,
+				Enc:         encoding.Binary,
 				Pref:        prefix.BerTLV,
 			}),
 			"9F36": NewHex(&Spec{
 				Description: "Currency Code, Application Reference",
-				Enc:         encoding.ASCIIHexToBytes,
+				Enc:         encoding.Binary,
 				Pref:        prefix.BerTLV,
 			}),
 			"9F3B": NewComposite(&Spec{
@@ -275,7 +275,7 @@ var (
 				Subfields: map[string]Field{
 					"9F45": NewHex(&Spec{
 						Description: "Data Authentication Code",
-						Enc:         encoding.ASCIIHexToBytes,
+						Enc:         encoding.Binary,
 						Pref:        prefix.BerTLV,
 					}),
 				},

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -513,7 +513,7 @@ func TestTLVPacking(t *testing.T) {
 		require.Equal(t, "047F", data.F9F3B.F9F45.Value())
 	})
 
-	t.Run("123Unpack correctly deserialises bytes to the data struct (constructed ber-tlv, unordered value)", func(t *testing.T) {
+	t.Run("Unpack correctly deserialises bytes to the data struct (constructed ber-tlv, unordered value)", func(t *testing.T) {
 		composite := NewComposite(constructedBERTLVTestSpec)
 
 		read, err := composite.Unpack([]byte{0x30, 0x31, 0x37, 0x9f, 0x36, 0x2, 0x2, 0x7f, 0x9f, 0x3b, 0x5, 0x9f, 0x45, 0x2, 0x4, 0x7f, 0x82, 0x2, 0x1, 0x7f})

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -233,12 +233,12 @@ var (
 			Sort: sort.StringsByHex,
 		},
 		Subfields: map[string]Field{
-			"9A": NewString(&Spec{
+			"9A": NewHex(&Spec{
 				Description: "Transaction Date",
 				Enc:         encoding.ASCIIHexToBytes,
 				Pref:        prefix.BerTLV,
 			}),
-			"9F02": NewString(&Spec{
+			"9F02": NewHex(&Spec{
 				Description: "Amount, Authorized (Numeric)",
 				Enc:         encoding.ASCIIHexToBytes,
 				Pref:        prefix.BerTLV,
@@ -255,12 +255,12 @@ var (
 			Sort: sort.StringsByHex,
 		},
 		Subfields: map[string]Field{
-			"82": NewString(&Spec{
+			"82": NewHex(&Spec{
 				Description: "Application Interchange Profile",
 				Enc:         encoding.ASCIIHexToBytes,
 				Pref:        prefix.BerTLV,
 			}),
-			"9F36": NewString(&Spec{
+			"9F36": NewHex(&Spec{
 				Description: "Currency Code, Application Reference",
 				Enc:         encoding.ASCIIHexToBytes,
 				Pref:        prefix.BerTLV,
@@ -273,7 +273,7 @@ var (
 					Sort: sort.StringsByHex,
 				},
 				Subfields: map[string]Field{
-					"9F45": NewString(&Spec{
+					"9F45": NewHex(&Spec{
 						Description: "Data Authentication Code",
 						Enc:         encoding.ASCIIHexToBytes,
 						Pref:        prefix.BerTLV,
@@ -306,18 +306,18 @@ type CompositeTestDataWithoutTagPaddingWithIndexTag struct {
 }
 
 type TLVTestData struct {
-	F9A   *String
-	F9F02 *String
+	F9A   *Hex
+	F9F02 *Hex
 }
 
 type ConstructedTLVTestData struct {
-	F82   *String
-	F9F36 *String
+	F82   *Hex
+	F9F36 *Hex
 	F9F3B *SubConstructedTLVTestData
 }
 
 type SubConstructedTLVTestData struct {
-	F9F45 *String
+	F9F45 *Hex
 }
 
 func TestComposite_SetData(t *testing.T) {
@@ -334,8 +334,8 @@ func TestCompositeFieldUnmarshal(t *testing.T) {
 		// we will do it by packing the field
 		composite := NewComposite(tlvTestSpec)
 		err := composite.SetData(&TLVTestData{
-			F9A:   NewStringValue("210720"),
-			F9F02: NewStringValue("000000000501"),
+			F9A:   NewHexValue("210720"),
+			F9F02: NewHexValue("000000000501"),
 		})
 		require.NoError(t, err)
 
@@ -353,10 +353,10 @@ func TestCompositeFieldUnmarshal(t *testing.T) {
 	t.Run("Unmarshal gets data for composite field (constructed)", func(t *testing.T) {
 		composite := NewComposite(constructedBERTLVTestSpec)
 		err := composite.SetData(&ConstructedTLVTestData{
-			F82:   NewStringValue("017F"),
-			F9F36: NewStringValue("027F"),
+			F82:   NewHexValue("017F"),
+			F9F36: NewHexValue("027F"),
 			F9F3B: &SubConstructedTLVTestData{
-				F9F45: NewStringValue("047F"),
+				F9F45: NewHexValue("047F"),
 			},
 		})
 		require.NoError(t, err)
@@ -375,15 +375,15 @@ func TestCompositeFieldUnmarshal(t *testing.T) {
 
 	t.Run("Unmarshal gets data for composite field using field tag `index`", func(t *testing.T) {
 		type tlvTestData struct {
-			Date          *String `index:"9A"`
-			TransactionID *String `index:"9F02"`
+			Date          *Hex `index:"9A"`
+			TransactionID *Hex `index:"9F02"`
 		}
 		// first, we need to populate fields of composite field
 		// we will do it by packing the field
 		composite := NewComposite(tlvTestSpec)
 		err := composite.SetData(&TLVTestData{
-			F9A:   NewStringValue("210720"),
-			F9F02: NewStringValue("000000000501"),
+			F9A:   NewHexValue("210720"),
+			F9F02: NewHexValue("000000000501"),
 		})
 		require.NoError(t, err)
 
@@ -402,8 +402,8 @@ func TestCompositeFieldUnmarshal(t *testing.T) {
 func TestTLVPacking(t *testing.T) {
 	t.Run("Pack correctly serializes data to bytes (general tlv)", func(t *testing.T) {
 		data := &TLVTestData{
-			F9A:   NewStringValue("210720"),
-			F9F02: NewStringValue("000000000501"),
+			F9A:   NewHexValue("210720"),
+			F9F02: NewHexValue("000000000501"),
 		}
 
 		composite := NewComposite(tlvTestSpec)
@@ -465,10 +465,10 @@ func TestTLVPacking(t *testing.T) {
 
 	t.Run("Pack correctly serializes data to bytes (constructed ber-tlv)", func(t *testing.T) {
 		data := &ConstructedTLVTestData{
-			F82:   NewStringValue("017f"),
-			F9F36: NewStringValue("027f"),
+			F82:   NewHexValue("017f"),
+			F9F36: NewHexValue("027f"),
 			F9F3B: &SubConstructedTLVTestData{
-				F9F45: NewStringValue("047f"),
+				F9F45: NewHexValue("047f"),
 			},
 		}
 
@@ -1671,8 +1671,8 @@ func TestTLVJSONConversion(t *testing.T) {
 
 	t.Run("MarshalJSON TLV Data Ok", func(t *testing.T) {
 		data := &TLVTestData{
-			F9A:   NewStringValue("210720"),
-			F9F02: NewStringValue("000000000501"),
+			F9A:   NewHexValue("210720"),
+			F9F02: NewHexValue("000000000501"),
 		}
 
 		composite := NewComposite(tlvTestSpec)

--- a/field/hex.go
+++ b/field/hex.go
@@ -14,7 +14,11 @@ var _ Field = (*Hex)(nil)
 var _ json.Marshaler = (*Hex)(nil)
 var _ json.Unmarshaler = (*Hex)(nil)
 
-// Hex is a field that contains a hex string value, but is encoded as binary
+// Hex field allows working with hex strings but under the hood it's a binary
+// field. It's convenient to use when you need to work with hex strings, but
+// don't want to deal with converting them to bytes manually.
+// If provided value is not a valid hex string, it will return an error during
+// packing.
 type Hex struct {
 	value string
 	spec  *Spec

--- a/field/hex_test.go
+++ b/field/hex_test.go
@@ -1,0 +1,144 @@
+package field
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexField(t *testing.T) {
+	spec := &Spec{
+		Length:      5, // 5 bytes, 10 hex chars
+		Description: "Field",
+		Enc:         encoding.Binary,
+		Pref:        prefix.ASCII.Fixed,
+	}
+
+	t.Run("packing", func(t *testing.T) {
+		f := NewHexValue("AABBCCDDEE")
+		f.SetSpec(spec)
+
+		packed, err := f.Pack()
+
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee}, packed)
+	})
+
+	t.Run("unpacking", func(t *testing.T) {
+		f := NewHex(spec)
+		read, err := f.Unpack([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee})
+
+		require.NoError(t, err)
+		require.Equal(t, 5, read)
+		require.Equal(t, "AABBCCDDEE", f.Value())
+	})
+
+	t.Run("marshaling", func(t *testing.T) {
+		f := NewHexValue("AABBCCDDEE")
+		f2 := &Hex{}
+
+		f2.Marshal(f)
+
+		require.Equal(t, f.Value(), f2.Value())
+	})
+
+	t.Run("unmarshaling", func(t *testing.T) {
+		f := NewHexValue("AABBCCDDEE")
+		f2 := &Hex{}
+
+		f.Unmarshal(f2)
+
+		require.Equal(t, f.Value(), f2.Value())
+	})
+
+	t.Run("JSON marshaling/unmarshaling", func(t *testing.T) {
+		// when marshaling, we should get the hex string, not base64
+		f := NewHexValue("AABBCCDDEE")
+		f.SetSpec(spec)
+
+		b, err := f.MarshalJSON()
+		require.NoError(t, err)
+		require.Equal(t, "\"AABBCCDDEE\"", string(b))
+
+		var f2 Hex
+		err = f2.UnmarshalJSON(b)
+		require.NoError(t, err)
+		require.Equal(t, f.Value(), f2.Value())
+	})
+
+	t.Run("methods", func(t *testing.T) {
+		f := NewHex(spec)
+		f.SetBytes([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee})
+
+		require.Equal(t, "AABBCCDDEE", f.Value())
+
+		str, err := f.String()
+		require.NoError(t, err)
+		require.Equal(t, "AABBCCDDEE", str)
+
+		b, err := f.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee}, b)
+
+		// SetValue
+		f.SetValue("EEBBCCDDEE")
+		require.Equal(t, "EEBBCCDDEE", f.Value())
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		f := NewHex(spec)
+		f.SetBytes([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee})
+
+		// invalid length
+		f.SetValue("AABBCCDDE")
+
+		_, err := f.Bytes()
+		require.EqualError(t, err, "encoding/hex: odd length hex string")
+
+		// invalid hex
+		f.SetValue("AABBCCDDEG")
+		_, err = f.Bytes()
+		require.EqualError(t, err, "encoding/hex: invalid byte: U+0047 'G'")
+
+		_, err = f.Pack()
+		require.EqualError(t, err, "converting hex field into bytes")
+
+		var e *utils.SafeError
+		require.True(t, errors.As(err, &e))
+		require.Equal(t, "converting hex field into bytes: encoding/hex: invalid byte: U+0047 'G'", e.UnsafeError())
+	})
+}
+
+func TestHexNil(t *testing.T) {
+	var f *Hex = nil
+
+	bs, err := f.Bytes()
+	require.NoError(t, err)
+	require.Nil(t, bs)
+
+	value, err := f.String()
+	require.NoError(t, err)
+	require.Equal(t, "", value)
+
+	value = f.Value()
+	require.Equal(t, "", value)
+}
+
+func TestHexPack(t *testing.T) {
+	t.Run("returns error for zero value when fixed length and no padding specified", func(t *testing.T) {
+		spec := &Spec{
+			Length:      10,
+			Description: "Field",
+			Enc:         encoding.ASCII,
+			Pref:        prefix.ASCII.Fixed,
+		}
+		str := NewHex(spec)
+		_, err := str.Pack()
+
+		require.EqualError(t, err, "failed to encode length: field length: 0 should be fixed: 10")
+	})
+}

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -97,7 +97,7 @@ func (f *Numeric) Pack() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/spec.go
+++ b/field/spec.go
@@ -40,8 +40,12 @@ type TagSpec struct {
 
 // Spec defines the structure of a field.
 type Spec struct {
-	// Length defines the maximum length of field (bytes, characters or
-	// digits), for both fixed and variable lengths.
+	// Length defines the maximum length of field (bytes, characters,
+	// digits or hex digits), for both fixed and variable lengths.
+	// You should use appropriate field types corresponding to the
+	// length of the field you're defining, e.g. Numeric, String, Binary
+	// etc. For Hex fields, the length is defined in terms of the number
+	// of bytes, while the value of the field is hex string.
 	Length int
 	// Tag sets the tag specification. Only applicable to composite field
 	// types.

--- a/field/track1.go
+++ b/field/track1.go
@@ -77,7 +77,7 @@ func (f *Track1) Pack() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/track2.go
+++ b/field/track2.go
@@ -76,7 +76,7 @@ func (f *Track2) Pack() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/track3.go
+++ b/field/track3.go
@@ -74,7 +74,7 @@ func (f *Track3) Pack() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode content: %w", err)
 	}
 
-	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}


### PR DESCRIPTION
This PR fixes the issue we have with packing/unpacking field values for which 1 input byte does not match 1 output byte.

## Context

In the current approach, when we pack the field value, we pass the length of the encoded data to the prefixer. Here is the code for the `String` field:

```go
func (f *String) Pack() ([]byte, error) {
	data := []byte(f.value)
	// ...
	packed, err := f.spec.Enc.Encode(data)
	// ...
	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
```

The issue here is that the prefixer encodes the length of the packed value, not the original value.

## Why we haven't noticed such a bug before?

It's because this worked well for most of the cases when 1 input byte matches 1 output byte. Let's say you have a string and you encode it into `ASCII`, or you have a slice of bytes (`Binary` field) and you encode it using `Binary` encoding. For such cases, `len(packed)` is equal to `len(f.value)`.

But for BCD, where 1 byte represents 2 digits, it does not work. That was reported by @ddvk in the issue https://github.com/moov-io/iso8583/issues/220.

So, when you encode `"12"` into BCD, you will get 1 byte `0x12` and currently, when we pack the field, the prefixer will encode the length of 1 byte, not 2 digits. When you decode it, the prefixer returns the length of `1` which is a byte, but BCD decoder expects to decode two digits (`"12"`) and having `1` as the data length argument to Decode will drop the first digit and return only `"2"` instead of `"12"`.

Here is how we `Unpack` value:

```go
	// prefixer returns length of the data: dataLen
	dataLen, prefBytes, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
	if err != nil {
		return 0, fmt.Errorf("failed to decode length: %w", err)
	}

	// BCD decoder knows that for two digits it should read 1 byte 
	raw, read, err := f.spec.Enc.Decode(data[prefBytes:], dataLen)
	if err != nil {
		return 0, fmt.Errorf("failed to decode content: %w", err)
	}
```

## Changes

To fix this, we changed how fields are packed - they use the length of the field value, not the encoded value.

## Breaking Change

This PR breaks some tests and most probably can break your code if you use the following together:

* use `String` field to store hex string like: `NewStringValue("210720")`
* use `ASCIIHEXToBytes` encoder to encode hex string into bytes

Such a combination in tests is frequently used for BerTLV composite fields (EMV, ICC, etc.).

### Why it's broken?

**First**, when we pack value, `ASCIIHEXToBytes` converts the hex string to bytes and the length of the encoded value does not match the original value (the hex string is twice longer) changes made for packing, will use length of the original value instead of the length of encoded value how it was before. 

**Second**, when we unpack value, BerTLV prefix returns the length of the value in bytes. Using hex string to store value of tag will not work as the hex string length does not match the length of the value in bytes.

### How to fix it?

The main fix is to stop using `ASCIIHexToBytes` encoding with the `String` field.

There are two options:

1. Use the new `Hex` field added in this PR together with the `Binary` encoding. The `Hex` field allows you to work with a hex string when you set or get the value of the field, but when the field is packed or unpacked, it will use encoded bytes instead of a string.

```go
	// ...
	Subfields: map[string]Field{
			"9A": NewHex(&Spec{
				Description: "Transaction Date",
				Enc:         encoding.Binary,
				Pref:        prefix.BerTLV,
			}),

	// ...

	// work with hex string, which will be treated as bytes during packing/unpacking
	data := &TLVTestData{
		F9A:   NewHexValue("210720"),
		F9F02: NewHexValue("000000000501"),
	}
```

2. Use `Binary` field together with the `Binary` encoding and manually set values of the `Binary` field.

```go
	// define BerTLV tags as Binary
	"9F02": NewBinary(&Spec{
		Description: "Amount, Authorized (Numeric)",
		Enc:         encoding.Binary,
		Pref:        prefix.BerTLV,
	}),

	// manually convert hex string into bytes
	f9f02, err := hex.DecodeString("000000000501")
	// ...

	err = composite.SetData(&TLVTestData{
		// work with binary value here
		F9F02: NewBinaryValue(f9f02),
	})
```

fixes https://github.com/moov-io/iso8583/issues/220