### PR TITLE
JSON (un)marshal Bitmap field

### DIFF
--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -1,7 +1,10 @@
 package field
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -205,4 +208,27 @@ func (f *Bitmap) IsSet(n int) bool {
 
 func (f *Bitmap) Len() int {
 	return len(f.data) * 8
+}
+
+func (f *Bitmap) MarshalJSON() ([]byte, error) {
+	data, err := f.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve bytes: %v", err)
+	}
+	return json.Marshal(strings.ToUpper(hex.EncodeToString(data)))
+}
+
+// Takes in a HEX based string
+func (f *Bitmap) UnmarshalJSON(b []byte) error {
+	unqouted, err := strconv.Unquote(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to unquote input: %w", err)
+	}
+
+	bs, err := hex.DecodeString(unqouted)
+	if err != nil {
+		return fmt.Errorf("failed to decode hex string: %w", err)
+	}
+
+	return f.SetBytes(bs)
 }

--- a/message.go
+++ b/message.go
@@ -218,12 +218,6 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	fieldMap := m.GetFields()
 	strFieldMap := map[string]field.Field{}
 	for id, field := range fieldMap {
-		// we don't wish to populate the bitmap in the final
-		// JSON since it is dynamically generated when packing
-		// and unpacking anyways.
-		if id == bitmapIdx {
-			continue
-		}
 		strFieldMap[fmt.Sprint(id)] = field
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -721,7 +721,7 @@ func TestMessageJSON(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		want := `{"0":"0100","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100","45":{"fixed_length":true,"format_code":"B","primary_account_number":"1234567890123445","name":"PADILLA/L.","expiration_date":"1999-01-01T00:00:00Z","service_code":"120","discretionary_data":"0000000000000**XXX******"}}`
+		want := `{"0":"0100","1":"7000000000080000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100","45":{"fixed_length":true,"format_code":"B","primary_account_number":"1234567890123445","name":"PADILLA/L.","expiration_date":"1999-01-01T00:00:00Z","service_code":"120","discretionary_data":"0000000000000**XXX******"}}`
 
 		got, err := json.Marshal(message)
 		require.NoError(t, err)
@@ -734,7 +734,7 @@ func TestMessageJSON(t *testing.T) {
 		message.Field(2, "4242424242424242")
 		message.Field(4, "100")
 
-		want := `{"0":"0100","2":"4242424242424242","4":"100"}`
+		want := `{"0":"0100","1":"5000000000000000","2":"4242424242424242","4":"100"}`
 
 		got, err := json.Marshal(message)
 		require.NoError(t, err)
@@ -755,7 +755,7 @@ func TestMessageJSON(t *testing.T) {
 			F4 *field.String
 		}
 
-		want := `{"0":"0100","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
+		want := `{"0":"0100","1":"7000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
 
 		message := NewMessage(spec)
 		message.SetData(&ISO87Data{})
@@ -769,7 +769,7 @@ func TestMessageJSON(t *testing.T) {
 	})
 
 	t.Run("Test JSON encoding of unpacked fields untyped", func(t *testing.T) {
-		want := `{"0":"0100","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
+		want := `{"0":"0100","1":"7000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
 
 		message := NewMessage(spec)
 
@@ -784,7 +784,7 @@ func TestMessageJSON(t *testing.T) {
 	t.Run("Test JSON decoding typed", func(t *testing.T) {
 		message := NewMessage(spec)
 
-		input := []byte(`{"0":"0100","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`)
+		input := []byte(`{"0":"0100","1":"7000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`)
 
 		want := &TestISOData{
 			F0: field.NewStringValue("0100"),
@@ -813,7 +813,7 @@ func TestMessageJSON(t *testing.T) {
 	t.Run("Test JSON decoding untyped", func(t *testing.T) {
 		message := NewMessage(spec)
 
-		input := `{"0":"0100","2":"4242424242424242","4":"100"}`
+		input := `{"0":"0100","1":"5000000000000000","2":"4242424242424242","4":"100"}`
 
 		err := json.Unmarshal([]byte(input), message)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR allows the `Bitmap` fields to be JSON (un) marshaled.

In #133 we removed the marshaling and unmarshaling of the `Bitmap` field. I believe if we're using JSON to represent messages, it could also incorporate a bitmap. This would be beneficial for viewing the bitmap's hex representation when marshaling the message into JSON. However, the downside is that unmarshaling doesn't ensure the bitmap's accuracy. For instance, if some fields are removed from the JSON, the remaining fields and bitmap could still be unmarshaled without issue. The problem arises as the bitmap no longer accurately reflects the original set of fields.

Would love to get some feedback about it.
