### PR TITLE
Skip bitmap presence bits when pack and unpack message

### DIFF
--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -232,3 +232,25 @@ func (f *Bitmap) UnmarshalJSON(b []byte) error {
 
 	return f.SetBytes(bs)
 }
+
+// IsBitmapPresenceBit checks if the bit at position n in the bitmap is an
+// indicator of the presence of an additional bitmap. For fixed-length bitmaps
+// (when DisableAutoExpand is set in the specification), this method will
+// always return false since additional bitmaps are not applicable.
+func (f *Bitmap) IsBitmapPresenceBit(n int) bool {
+	// there are not presence bits in fixed bitmaps
+	if f.spec.DisableAutoExpand {
+		return false
+	}
+
+	if n <= 0 {
+		return false
+	}
+
+	// check if n is the first bit of a bitmap
+	if n%(f.bitmapLength*8) == 1 {
+		return true
+	}
+
+	return false
+}

--- a/message.go
+++ b/message.go
@@ -210,6 +210,11 @@ func (m *Message) unpack(src []byte) error {
 	off += read
 
 	for i := 2; i <= m.Bitmap().Len(); i++ {
+		// skip bitmap presence bits (for default bitmap length of 64 these are bits 1, 65, 129, 193, etc.)
+		if m.Bitmap().IsBitmapPresenceBit(i) {
+			continue
+		}
+
 		if m.Bitmap().IsSet(i) {
 			fl, ok := m.fields[i]
 			if !ok {

--- a/message.go
+++ b/message.go
@@ -149,7 +149,8 @@ func (m *Message) pack() ([]byte, error) {
 	for _, id := range ids {
 		// indexes 0 and 1 are for mti and bitmap
 		// regular field number startd from index 2
-		if id < 2 {
+		// do not pack presence bits as well
+		if id < 2 || m.Bitmap().IsBitmapPresenceBit(id) {
 			continue
 		}
 		m.Bitmap().Set(id)
@@ -157,6 +158,11 @@ func (m *Message) pack() ([]byte, error) {
 
 	// pack fields
 	for _, i := range ids {
+		// do not pack presence bits other than the first one as it's the bitmap itself
+		if i != 1 && m.Bitmap().IsBitmapPresenceBit(i) {
+			continue
+		}
+
 		field, ok := m.fields[i]
 		if !ok {
 			return nil, fmt.Errorf("failed to pack field %d: no specification found", i)


### PR DESCRIPTION
closes #254 

This PR adds the `IsBitmapPresenceBit` method to the `Bitmap`, allowing us to ignore fields that have the same index as bits, which indicate the presence of the next bitmap. By using this method, we can skip these fields when packing and unpacking a message.