### PR TITLE
check for the max length in BerTLV prefix

### DIFF
--- a/prefix/bertlv_test.go
+++ b/prefix/bertlv_test.go
@@ -36,6 +36,16 @@ func TestBerTLVPrefixer(t *testing.T) {
 			require.Equal(t, tt.numBytes, read)
 		})
 	}
+
+	t.Run("when maxLen is set EncodeLength returns error if length is larger than maxLen", func(t *testing.T) {
+		_, err := BerTLV.EncodeLength(2, 3)
+		require.EqualError(t, err, "field length: 3 is larger than maximum: 2")
+	})
+
+	t.Run("when maxLen is set DecodeLength returns error if length is larger than maxLen", func(t *testing.T) {
+		_, _, err := BerTLV.DecodeLength(2, []byte{0b10000010, 0b11111110, 0b00001111})
+		require.EqualError(t, err, "field length: 65039 is larger than maximum: 2")
+	})
 }
 
 func TestBerTLVPrefixer_DecodeReturnsErrOnIncorrectInput(t *testing.T) {


### PR DESCRIPTION
In the spec I'm working with now, there is a max length for BerTLV fields.

Currently, we are ignoring the `Length` (max length) of the field spec for `prefix.BerTLV`. This PR changes the prefix a little bit:
* if `Length` is set to `0` or is not set (`0` is zero value used for the `Length` anyway) - we do not check max length - this is to support current integrations which, most probably, follow the example from our tests like this:
```go
				Subfields: map[string]field.Field{
					"9A": field.NewString(&field.Spec{
						Description: "Transaction Date",
						Enc:         encoding.Binary,
						Pref:        prefix.BerTLV,
					}),
					"9F02": field.NewString(&field.Spec{
						Description: "Amount, Authorized (Numeric)",
						Enc:         encoding.Binary,
						Pref:        prefix.BerTLV,
					}),
				},
```
* if `Length` is set to non-zero value, perform the check

**This PR is a breaking change** (potentially) if you use the `prefix.BerTLV` and set non-zero `Length` in the field spec.

