### PR TITLE
Fix the order of the map

### DIFF
--- a/field/ordered_map.go
+++ b/field/ordered_map.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/moov-io/iso8583/utils"
 )
@@ -17,8 +18,7 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 	for k := range om {
 		keys = append(keys, k)
 	}
-
-	sort.Strings(keys)
+	sort.Sort(sortImpl(keys))
 
 	buf := &bytes.Buffer{}
 	buf.Write([]byte{'{'})
@@ -40,4 +40,20 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 	buf.Write([]byte{'}'})
 
 	return buf.Bytes(), nil
+}
+
+type sortImpl []string
+
+func (a sortImpl) Len() int      { return len(a) }
+func (a sortImpl) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a sortImpl) Less(i, j int) bool {
+	numLeft, err := strconv.ParseUint(a[i], 10, 0)
+	if err != nil {
+		return a[i] < a[j]
+	}
+	numRight, err := strconv.ParseUint(a[j], 10, 0)
+	if err != nil {
+		return a[i] < a[j]
+	}
+	return numLeft < numRight
 }

--- a/field/ordered_map_test.go
+++ b/field/ordered_map_test.go
@@ -1,0 +1,40 @@
+package field
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	testOrderedMap = OrderedMap{
+		"0":   &String{value: "0100"},
+		"1":   &String{value: "D00080000000000000000000002000000000000000000000"},
+		"107": &String{value: "102"},
+		"17":  &String{value: "101"},
+		"2":   &String{value: "4242424242424242"},
+		"4":   &String{value: "100"},
+		"a":   &String{value: "555"},
+		"z":   &String{value: "555"},
+	}
+)
+
+func TestOrderedMap_MarshalJSON(t *testing.T) {
+	expected := `{"0":"0100","1":"D00080000000000000000000002000000000000000000000","2":"4242424242424242","4":"100","17":"101","107":"102","a":"555","z":"555"}`
+	data, err := json.Marshal(testOrderedMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != expected {
+		t.Errorf("Marshalled value should be \n\t%s\ninstead of \n\t%s", expected, string(data))
+	}
+}
+
+func BenchmarkOrderedMap_MarshalJSON(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(testOrderedMap)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Resolve #125

I wrote a custom sort implementation this scenario. I know that by the documentation it shouldn't have letters in that key, but I wanted to handle that case as well, where the map's key is a letter or non-numeric.

Benchmarks:
```
// Previous solution with sort.Strings(...)
//         BenchmarkOrderedMap_MarshalJSON-8         250574          4697 ns/op        1329 B/op          46 allocs/op
// New solution with custom sort algorithm
//         BenchmarkOrderedMap_MarshalJSON-8         211605          5277 ns/op        1707 B/op          53 allocs/op
```

I think there can be a few performance improvements especially for the `strconv.ParseUint`.