### PR TITLE
Experimental: simplify data structs

### DIFF
--- a/exp_test.go
+++ b/exp_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/moov-io/iso8583"
+	"github.com/moov-io/iso8583/field"
 	"github.com/moov-io/iso8583/specs"
 	"github.com/stretchr/testify/require"
 )
@@ -163,5 +164,43 @@ func TestStructWithTypes(t *testing.T) {
 				require.Equal(t, tt.expectedPackedString, string(packed))
 			})
 		}
+	})
+
+	t.Run("unpack", func(t *testing.T) {
+		type authRequest struct {
+			MTI                  string `index:"0"`
+			PrimaryAccountNumber string `index:"2"`
+		}
+
+		packed := []byte("011040000000000000000000000000000000164242424242424242")
+
+		message := iso8583.NewMessage(specs.Spec87ASCII)
+		err := message.Unpack(packed)
+		require.NoError(t, err)
+
+		data := authRequest{}
+		err = message.Unmarshal(&data)
+		require.NoError(t, err)
+		require.Equal(t, "0110", data.MTI)
+		require.Equal(t, "4242424242424242", data.PrimaryAccountNumber)
+	})
+
+	t.Run("unpack2", func(t *testing.T) {
+		type authRequest struct {
+			MTI                  *string       `index:"0"`
+			PrimaryAccountNumber *field.String `index:"2"`
+		}
+
+		packed := []byte("011040000000000000000000000000000000164242424242424242")
+
+		message := iso8583.NewMessage(specs.Spec87ASCII)
+		err := message.Unpack(packed)
+		require.NoError(t, err)
+
+		data := authRequest{}
+		err = message.Unmarshal(&data)
+		require.NoError(t, err)
+		require.Equal(t, "0110", *data.MTI)
+		require.Equal(t, "4242424242424242", data.PrimaryAccountNumber.Value())
 	})
 }

--- a/exp_test.go
+++ b/exp_test.go
@@ -13,23 +13,162 @@ func TestStructWithTypes(t *testing.T) {
 		MTI                  string `index:"0"`
 		PrimaryAccountNumber string `index:"2"`
 		ProcessingCode       int    `index:"3"`
-		TransactionAmount    int    `index:"4,keepzero"` // we will set message field value to 0
+		TransactionAmount    *int   `index:"4,keepzero"` // we will set message field value to 0
 	}
 
 	t.Run("pack", func(t *testing.T) {
-		authRequest := &authRequestData{
-			MTI:                  "0110",
-			PrimaryAccountNumber: "4242424242424242",
-			ProcessingCode:       200000,
+		panInt := 4242424242424242
+		panStr := "4242424242424242"
+
+		tests := []struct {
+			name                 string
+			input                interface{}
+			expectedPackedString string
+		}{
+			// Tests for string type
+			{
+				name: "struct with string type and value set",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber string `index:"2"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: panStr,
+				},
+				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
+			},
+			{
+				name: "struct with string type and no value",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber string `index:"2"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
+			{
+				name: "struct with string type, no value and keepzero tag - length prefix is set to 0 and no value is following",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber string `index:"2,keepzero"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "01104000000000000000000000000000000000",
+			},
+
+			// Tests for *string type
+			{
+				name: "struct with *string type and value set",
+				input: struct {
+					MTI                  string  `index:"0"`
+					PrimaryAccountNumber *string `index:"2"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: &panStr,
+				},
+				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
+			},
+			{
+				name: "struct with *string type and no value",
+				input: struct {
+					MTI                  string  `index:"0"`
+					PrimaryAccountNumber *string `index:"2"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
+			{
+				name: "struct with *string type, no value and keepzero tag",
+				input: struct {
+					MTI                  string  `index:"0"`
+					PrimaryAccountNumber *string `index:"2,keepzero"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
+
+			// Tests for int type
+			{
+				name: "struct with int type and value set",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber int    `index:"2"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: panInt,
+				},
+				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
+			},
+			{
+				name: "struct with int type and no value",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber int    `index:"2"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
+			{
+				name: "struct with int type, no value and keepzero tag",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber int    `index:"2,keepzero"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011040000000000000000000000000000000010",
+			},
+
+			// Tests for *int type
+			{
+				name: "struct with *int type and value set",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber *int   `index:"2"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: &panInt,
+				},
+				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
+			},
+			{
+				name: "struct with *int type and no value",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber *int   `index:"2"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
+			{
+				name: "struct with *int type, no value and keepzero tag",
+				input: struct {
+					MTI                  string `index:"0"`
+					PrimaryAccountNumber *int   `index:"2,keepzero"`
+				}{
+					MTI: "0110",
+				},
+				expectedPackedString: "011000000000000000000000000000000000",
+			},
 		}
 
-		message := iso8583.NewMessage(specs.Spec87ASCII)
-		err := message.Marshal(authRequest)
-		require.NoError(t, err)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				message := iso8583.NewMessage(specs.Spec87ASCII)
+				err := message.Marshal(tt.input)
+				require.NoError(t, err)
 
-		packed, err := message.Pack()
-		require.NoError(t, err)
+				packed, err := message.Pack()
+				require.NoError(t, err)
 
-		require.Equal(t, "011070000000000000000000000000000000164242424242424242200000000000000000", string(packed))
+				require.Equal(t, tt.expectedPackedString, string(packed))
+			})
+		}
 	})
 }

--- a/exp_test.go
+++ b/exp_test.go
@@ -9,13 +9,6 @@ import (
 )
 
 func TestStructWithTypes(t *testing.T) {
-	type authRequestData struct {
-		MTI                  string `index:"0"`
-		PrimaryAccountNumber string `index:"2"`
-		ProcessingCode       int    `index:"3"`
-		TransactionAmount    *int   `index:"4,keepzero"` // we will set message field value to 0
-	}
-
 	t.Run("pack", func(t *testing.T) {
 		panInt := 4242424242424242
 		panStr := "4242424242424242"

--- a/exp_test.go
+++ b/exp_test.go
@@ -1,0 +1,34 @@
+package iso8583_test
+
+import (
+	"testing"
+
+	"github.com/moov-io/iso8583"
+	"github.com/moov-io/iso8583/specs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructWithTypes(t *testing.T) {
+	type authRequestData struct {
+		MTI                  string `index:"0"`
+		PrimaryAccountNumber string `index:"2"`
+		ProcessingCode       int    `index:"3"`
+	}
+
+	t.Run("pack", func(t *testing.T) {
+		authRequest := &authRequestData{
+			MTI:                  "0110",
+			PrimaryAccountNumber: "4242424242424242",
+			ProcessingCode:       200000,
+		}
+
+		message := iso8583.NewMessage(specs.Spec87ASCII)
+		err := message.Marshal(authRequest)
+		require.NoError(t, err)
+
+		packed, err := message.Pack()
+		require.NoError(t, err)
+
+		require.Equal(t, "011060000000000000000000000000000000164242424242424242200000", string(packed))
+	})
+}

--- a/exp_test.go
+++ b/exp_test.go
@@ -13,6 +13,7 @@ func TestStructWithTypes(t *testing.T) {
 		MTI                  string `index:"0"`
 		PrimaryAccountNumber string `index:"2"`
 		ProcessingCode       int    `index:"3"`
+		TransactionAmount    int    `index:"4,keepzero"` // we will set message field value to 0
 	}
 
 	t.Run("pack", func(t *testing.T) {
@@ -29,6 +30,6 @@ func TestStructWithTypes(t *testing.T) {
 		packed, err := message.Pack()
 		require.NoError(t, err)
 
-		require.Equal(t, "011060000000000000000000000000000000164242424242424242200000", string(packed))
+		require.Equal(t, "011070000000000000000000000000000000164242424242424242200000000000000000", string(packed))
 	})
 }

--- a/field/composite.go
+++ b/field/composite.go
@@ -623,11 +623,16 @@ var fieldNameTagRe = regexp.MustCompile(`^F.+$`)
 // field name. If it does not match F.+ pattern, it checks value of `index`
 // tag.  If empty string, then index/tag was not found for the field.
 func getFieldIndexOrTag(field reflect.StructField) (string, error) {
-	dataFieldName := field.Name
-
-	if fieldIndex := field.Tag.Get("index"); fieldIndex != "" {
-		return fieldIndex, nil
+	var fieldIndex string
+	// keep the order of tags for now, when index tag is deprecated we can
+	// change the order
+	for _, tag := range []string{"index", "iso8583"} {
+		if fieldIndex = field.Tag.Get(tag); fieldIndex != "" {
+			return fieldIndex, nil
+		}
 	}
+
+	dataFieldName := field.Name
 
 	if len(dataFieldName) > 0 && fieldNameTagRe.MatchString(dataFieldName) {
 		return dataFieldName[1:], nil

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -595,7 +595,7 @@ func TestCompositePacking(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		require.EqualError(t, err, "failed to set data from field 1: data does not match required *String type")
+		require.Contains(t, err.Error(), "failed to set data from field 1: data does not match required *String")
 	})
 
 	t.Run("Pack returns error on failure of subfield packing", func(t *testing.T) {

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -745,7 +745,7 @@ func TestCompositePacking(t *testing.T) {
 		err = composite.Unmarshal(data)
 
 		require.Error(t, err)
-		require.EqualError(t, err, "failed to get data from field 1: data does not match required *String type")
+		require.Contains(t, err.Error(), "failed to get data from field 1: data does not match required *String")
 	})
 
 	t.Run("Unpack returns an error on failure of subfield to unpack bytes", func(t *testing.T) {

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"strconv"
 
 	"github.com/moov-io/iso8583/utils"
@@ -148,22 +147,35 @@ func (f *Numeric) SetData(data interface{}) error {
 		f.value = v.value
 	case int:
 		f.value = v
-	case int32:
-		if v >= math.MinInt32 && v <= math.MaxInt32 {
-			f.value = int(v)
-		} else {
-			return fmt.Errorf("int32 value out of range for int")
+	case *int:
+		if v == nil {
+			f.value = 0
+			return nil
 		}
-	case int64:
-		if v >= math.MinInt64 && v <= math.MaxInt64 {
-			f.value = int(v)
-		} else {
-			return fmt.Errorf("int64 value out of range for int")
+		f.value = *v
+	case string:
+		if v == "" {
+			f.value = 0
+			return nil
 		}
-	case []byte:
-		return f.SetBytes(v)
+		val, err := strconv.Atoi(v)
+		if err != nil {
+			return utils.NewSafeError(err, "failed to convert sting value into number")
+		}
+		f.value = val
+	case *string:
+		if v == nil {
+			f.value = 0
+			return nil
+		}
+
+		val, err := strconv.Atoi(*v)
+		if err != nil {
+			return utils.NewSafeError(err, "failed to convert sting value into number")
+		}
+		f.value = val
 	default:
-		return fmt.Errorf("data does not match require *Numeric or supported numeric types (int, int32, int64)")
+		return fmt.Errorf("data does not match require *Numeric or supported numeric types (int, *int, string, *string)")
 	}
 
 	return nil

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/moov-io/iso8583/utils"
@@ -143,6 +144,31 @@ func (f *Numeric) Unmarshal(v interface{}) error {
 }
 
 func (f *Numeric) SetData(data interface{}) error {
+	if v, ok := data.(reflect.Value); ok {
+		switch v.Kind() {
+		case reflect.Int:
+			f.value = int(v.Int())
+		case reflect.String:
+			val, err := strconv.Atoi(v.String())
+			if err != nil {
+				return utils.NewSafeError(err, "failed to convert into number")
+			}
+			f.value = val
+		default:
+			return fmt.Errorf("data does not match required *Numeric type")
+		}
+		return nil
+	}
+
+	// if v.Kind() == reflect.Int {
+	// }
+	// if v, ok := data.(reflect.Value); ok {
+	// 	if v.CanSet() {
+	// 		v.Set(reflect.ValueOf(f.value))
+	// 		return nil
+	// 	}
+	// }
+
 	if data == nil {
 		return nil
 	}

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -151,18 +151,9 @@ func TestNumericFieldZeroLeftPaddedZero(t *testing.T) {
 }
 
 func TestNumericSetBytesSetsDataOntoDataStruct(t *testing.T) {
-	numeric := NewNumeric(&Spec{
-		Length:      1,
-		Description: "Field",
-		Enc:         encoding.ASCII,
-		Pref:        prefix.ASCII.Fixed,
-	})
-
 	data := &Numeric{}
-	err := numeric.SetData(data)
-	require.NoError(t, err)
 
-	err = numeric.SetBytes([]byte("9"))
+	err := data.SetBytes([]byte("9"))
 	require.NoError(t, err)
 
 	require.Equal(t, 9, data.Value())

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -43,16 +43,7 @@ func TestNumericField(t *testing.T) {
 	require.Equal(t, "      9876", string(packed))
 
 	numeric = NewNumeric(spec)
-	data := NewNumericValue(0)
-	numeric.SetData(data)
-	length, err = numeric.Unpack([]byte("      9876"))
-	require.NoError(t, err)
-	require.Equal(t, 10, length)
-	require.Equal(t, 9876, data.Value())
-
-	numeric = NewNumeric(spec)
 	numeric.SetValue(9876)
-
 	require.Equal(t, 9876, numeric.Value())
 }
 

--- a/field/string.go
+++ b/field/string.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/moov-io/iso8583/utils"
 )
@@ -129,6 +130,20 @@ func (f *String) Unmarshal(v interface{}) error {
 }
 
 func (f *String) SetData(data interface{}) error {
+	if v, ok := data.(reflect.Value); ok {
+		switch v.Kind() {
+		case reflect.String:
+			f.value = v.String()
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.value = fmt.Sprintf("%d", v.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			f.value = fmt.Sprintf("%d", v.Uint())
+		default:
+			return fmt.Errorf("unsupported type %v", v.Kind())
+		}
+		return nil
+	}
+
 	if data == nil {
 		return nil
 	}

--- a/field/string.go
+++ b/field/string.go
@@ -137,14 +137,18 @@ func (f *String) SetData(data interface{}) error {
 			return nil
 		}
 		f.value = v
+	case *string:
+		if v == nil {
+			f.value = ""
+			return nil
+		}
+		f.value = *v
 	case int:
 		f.value = strconv.FormatInt(int64(v), 10)
-	case int32:
-		f.value = strconv.FormatInt(int64(v), 10)
-	case int64:
-		f.value = strconv.FormatInt(v, 10)
+	case *int:
+		f.value = strconv.FormatInt(int64(*v), 10)
 	default:
-		return fmt.Errorf("data does not match required *String or string type")
+		return fmt.Errorf("data does not match required *String or (string, *string, int, *int) type")
 	}
 
 	return nil

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -43,24 +43,8 @@ func TestStringField(t *testing.T) {
 	require.Equal(t, "     hello", string(packed))
 
 	str = NewString(spec)
-	data := NewStringValue("")
-	str.SetData(data)
-	length, err = str.Unpack([]byte("     olleh"))
-	require.NoError(t, err)
-	require.Equal(t, 10, length)
-	require.Equal(t, "olleh", data.Value())
-
-	str = NewString(spec)
-	data = &String{}
-	str.SetData(data)
-	err = str.SetBytes([]byte("hello"))
-	require.NoError(t, err)
-	require.Equal(t, "hello", data.Value())
-
-	str = NewString(spec)
-
 	str.SetValue("hello")
-	require.Equal(t, "hello", data.Value())
+	require.Equal(t, "hello", str.Value())
 }
 
 func TestStringNil(t *testing.T) {

--- a/field_tag.go
+++ b/field_tag.go
@@ -1,0 +1,93 @@
+package iso8583
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type FieldTag struct {
+	Id    int // is -1 if index is not a number
+	Index string
+
+	// KeepZero tells the marshaler to use zero value and set bitmap bit to
+	// 1 for this field. Default behavior is to omit the field from the
+	// message if it's zero value.
+	KeepZero bool
+}
+
+func NewFieldTag(field reflect.StructField) FieldTag {
+	// value of the key "index" in the tag
+	var value string
+
+	// keep the order of tags for now, when index tag is deprecated we can
+	// change the order
+	for _, tag := range []string{"index", "iso8583"} {
+		if value = field.Tag.Get(tag); value != "" {
+			break
+		}
+	}
+
+	// format of the value is "id[,keep_zero_value]"
+	// id is the id of the field
+	// let's parse it
+	if value != "" {
+		index, keepZero := parseValue(value)
+
+		id, err := strconv.Atoi(index)
+		if err != nil {
+			id = -1
+		}
+
+		return FieldTag{
+			Id:       id,
+			Index:    index,
+			KeepZero: keepZero,
+		}
+	}
+
+	dataFieldName := field.Name
+	if len(dataFieldName) > 0 && fieldNameIndexRe.MatchString(dataFieldName) {
+		indexStr := dataFieldName[1:]
+		fieldIndex, err := strconv.Atoi(indexStr)
+		if err != nil {
+			return FieldTag{
+				Id:    -1,
+				Index: indexStr,
+			}
+		}
+
+		return FieldTag{
+			Id:    fieldIndex,
+			Index: indexStr,
+		}
+	}
+
+	return FieldTag{
+		Id: -1,
+	}
+}
+
+func parseValue(value string) (index string, keepZero bool) {
+	if value == "" {
+		return
+	}
+
+	// split the value by comma
+	values := strings.Split(value, ",")
+
+	// the first value is the index
+	index = values[0]
+
+	// if there is only one value, return
+	if len(values) == 1 {
+		return
+	}
+
+	// if the second value is "keep_zero_value", set the flag
+	if values[1] == "keepzero" {
+		keepZero = true
+	}
+
+	return
+}

--- a/message.go
+++ b/message.go
@@ -376,7 +376,9 @@ func (m *Message) Marshal(v interface{}) error {
 			continue
 		}
 
-		err = messageField.Marshal(dataField.Interface())
+		err = messageField.Marshal(dataField)
+
+		// err = messageField.Marshal(dataField.Interface())
 		if err != nil {
 			return fmt.Errorf("failed to set value to field %d: %w", fieldIndex, err)
 		}

--- a/message.go
+++ b/message.go
@@ -433,11 +433,19 @@ func (m *Message) Unmarshal(v interface{}) error {
 		}
 
 		dataField := dataStruct.Field(i)
-		if dataField.IsNil() {
-			dataField.Set(reflect.New(dataField.Type().Elem()))
-		}
 
-		err = messageField.Unmarshal(dataField.Interface())
+		// if field is pointer we will pass pointer to the field
+		if dataField.Kind() == reflect.Ptr {
+			if dataField.IsZero() {
+				fmt.Println("is zero")
+				dataField.Set(reflect.New(dataField.Type().Elem()))
+			}
+
+			err = messageField.Unmarshal(dataField.Interface())
+		} else {
+			// if field is not pointer we will pass the field as reflect.Value
+			err = messageField.Unmarshal(dataField)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to get value from field %d: %w", fieldIndex, err)
 		}


### PR DESCRIPTION
The goal of this PR is to implement (now it's more like proof of concept) the proposal #277 to use go basic types in the data structs instead of `*field.String`, `*field.Numeric`, etc. like this:

```go
	type authRequestData struct {
		MTI                  string `index:"0"`
		PrimaryAccountNumber string `index:"2"`
		ProcessingCode       int    `index:"3"`
	}
```