### PR TITLE
Solve panic issues

### DIFF
--- a/message.go
+++ b/message.go
@@ -33,26 +33,18 @@ type Message struct {
 }
 
 func NewMessage(spec *MessageSpec) *Message {
-	// validate the spec
+	// Validate the spec
 	if err := spec.Validate(); err != nil {
 		panic(err) //nolint // as specs moslty static, we panic on spec validation errors
 	}
 
 	fields := spec.CreateMessageFields()
 
-	m := &Message{
+	return &Message{
 		fields:    fields,
 		spec:      spec,
 		fieldsMap: map[int]struct{}{},
 	}
-
-	// we validate the presence and type of the bitmap field
-	// in spec.Validate() so we can safely assume it exists
-	// and is of the correct type
-	m.bitmap, _ = m.fields[bitmapIdx].(*field.Bitmap)
-	m.fieldsMap[bitmapIdx] = struct{}{}
-
-	return m
 }
 
 // Deprecated. Use Marshal intead.
@@ -61,6 +53,17 @@ func (m *Message) SetData(data interface{}) error {
 }
 
 func (m *Message) Bitmap() *field.Bitmap {
+	if m.bitmap != nil {
+		return m.bitmap
+	}
+
+	// We validate the presence and type of the bitmap field in
+	// spec.Validate() when we create the message so we can safely assume
+	// it exists and is of the correct type
+	m.bitmap, _ = m.fields[bitmapIdx].(*field.Bitmap)
+	m.bitmap.Reset()
+	m.fieldsMap[bitmapIdx] = struct{}{}
+
 	return m.bitmap
 }
 

--- a/message_spec.go
+++ b/message_spec.go
@@ -12,6 +12,7 @@ type MessageSpec struct {
 	Fields map[int]field.Field
 }
 
+// Validate checks if the MessageSpec is valid.
 func (s *MessageSpec) Validate() error {
 	// we require MTI and Bitmap fields
 	if _, ok := s.Fields[mtiIdx]; !ok {

--- a/message_spec.go
+++ b/message_spec.go
@@ -1,6 +1,7 @@
 package iso8583
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/moov-io/iso8583/field"
@@ -9,6 +10,24 @@ import (
 type MessageSpec struct {
 	Name   string
 	Fields map[int]field.Field
+}
+
+func (s *MessageSpec) Validate() error {
+	// we require MTI and Bitmap fields
+	if _, ok := s.Fields[mtiIdx]; !ok {
+		return fmt.Errorf("MTI field (%d) is required", mtiIdx)
+	}
+
+	if _, ok := s.Fields[bitmapIdx]; !ok {
+		return fmt.Errorf("Bitmap field (%d) is required", bitmapIdx)
+	}
+
+	// check type of the bitmap field
+	if _, ok := s.Fields[bitmapIdx].(*field.Bitmap); !ok {
+		return fmt.Errorf("Bitmap field (%d) must be of type *field.Bitmap", bitmapIdx)
+	}
+
+	return nil
 }
 
 // Creates a map with new instances of Fields (Field interface)

--- a/sort/strings.go
+++ b/sort/strings.go
@@ -1,7 +1,6 @@
 package sort
 
 import (
-	"fmt"
 	"math/big"
 	"sort"
 	"strconv"
@@ -33,19 +32,21 @@ func StringsByInt(x []string) {
 	})
 }
 
-// StringsByHex sorts a slice of strings according to their big-endian Hex value.
-// This function panics in the event that an element in the slice cannot be
-// converted to a Hex slice. Each string representation of a hex value must be
-// of even length.
+// StringsByHex sorts a slice of strings according to their big-endian Hex
+// value. This function compares values as a regular strings in the event that
+// an element in the slice cannot be converted to a Hex slice. Each string
+// representation of a hex value must be of even length.
 func StringsByHex(x []string) {
 	sort.Slice(x, func(i, j int) bool {
 		valI, err := encoding.ASCIIHexToBytes.Encode([]byte(x[i]))
 		if err != nil {
-			panic(fmt.Sprintf("failed to encode ascii hex %s to bytes : %v", x[i], err))
+			// we will ignore the error and sort the strings as normal
+			return x[i] < x[j]
 		}
 		valJ, err := encoding.ASCIIHexToBytes.Encode([]byte(x[j]))
 		if err != nil {
-			panic(fmt.Sprintf("failed to sort strings by hex: %v", err))
+			// we will ignore the error and sort the strings as normal
+			return x[i] < x[j]
 		}
 		return new(big.Int).SetBytes(valI).Int64() < new(big.Int).SetBytes(valJ).Int64()
 	})

--- a/test/fuzz-reader/reader.go
+++ b/test/fuzz-reader/reader.go
@@ -40,7 +40,7 @@ func Fuzz(data []byte) int {
 
 	_, err = message.Pack()
 	if err != nil {
-		panic(fmt.Errorf("failed to pack unpacked message: %w", err))
+		panic(fmt.Errorf("failed to pack unpacked message: %w", err)) //nolint
 	}
 
 	return 1


### PR DESCRIPTION
Closes #270 

With this PR we:
* introduce `Validate()` method for `MessageSpec` and `field.Spec` - so if you don't want constructor to panic, you can validate your spec before.
* in `StringsByHex` if sorted value is not a Hex, we compare them as regular strings (no `panic`)
* ignore `panic` in fuzzer, I hope later we can address it 