### PR TITLE
Make the package safe for concurrent access

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -359,8 +359,6 @@ func (f *Composite) Bitmap() *Bitmap {
 }
 
 func (f *Composite) bitmap() *Bitmap {
-	// TODO: protect against concurrent access
-
 	if f.cachedBitmap != nil {
 		return f.cachedBitmap
 	}

--- a/field/composite.go
+++ b/field/composite.go
@@ -92,6 +92,9 @@ type CompositeWithSubfields interface {
 	ConstructSubfields()
 }
 
+// ConstructSubfields creates subfields according to the spec
+// this method is used when composite field is created without
+// calling NewComposite (when we create message spec and composite spec)
 func (f *Composite) ConstructSubfields() {
 	if f.subfields == nil {
 		f.subfields = CreateSubfields(f.spec)
@@ -120,7 +123,7 @@ func (f *Composite) GetSubfields() map[string]Field {
 // will result in a panic.
 func (f *Composite) SetSpec(spec *Spec) {
 	if err := spec.Validate(); err != nil {
-		panic(err) //nolint // as specs moslty static, we panic on spec validation errors
+		panic(err) // as specs moslty static, we panic on spec validation errors
 	}
 	f.spec = spec
 

--- a/field/composite.go
+++ b/field/composite.go
@@ -140,7 +140,7 @@ func (f *Composite) getSubfields() map[string]Field {
 // will result in a panic.
 func (f *Composite) SetSpec(spec *Spec) {
 	if err := spec.Validate(); err != nil {
-		panic(err) // as specs moslty static, we panic on spec validation errors
+		panic(err) //nolint:forbidigo,nolintlint // as specs moslty static, we panic on spec validation errors
 	}
 	f.spec = spec
 

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -1,9 +1,11 @@
 package field
 
 import (
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/moov-io/iso8583/encoding"
@@ -1890,5 +1892,62 @@ func TestComposite_getFieldIndexOrTag(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Empty(t, index)
+	})
+}
+
+func TestComposit_concurrency(t *testing.T) {
+	t.Run("Pack and Marshal", func(t *testing.T) {
+		// packing and marshaling
+		data := &TLVTestData{
+			F9A:   NewHexValue("210720"),
+			F9F02: NewHexValue("000000000501"),
+		}
+
+		composite := NewComposite(tlvTestSpec)
+
+		wg := sync.WaitGroup{}
+		wg.Add(5)
+
+		for i := 0; i < 5; i++ {
+			go func() {
+				defer wg.Done()
+
+				err := composite.Marshal(data)
+				require.NoError(t, err)
+
+				_, err = composite.Pack()
+				require.NoError(t, err)
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("Unpack and Unmarshal", func(t *testing.T) {
+		packed, err := hex.DecodeString("3031349A032107209F0206000000000501")
+		require.NoError(t, err)
+
+		composite := NewComposite(tlvTestSpec)
+
+		wg := sync.WaitGroup{}
+		wg.Add(5)
+
+		for i := 0; i < 5; i++ {
+			go func() {
+				defer wg.Done()
+
+				data := &TLVTestData{}
+				_, err := composite.Unpack(packed)
+				require.NoError(t, err)
+
+				err = composite.Unmarshal(data)
+				require.NoError(t, err)
+
+				require.Equal(t, "210720", data.F9A.Value())
+				require.Equal(t, "000000000501", data.F9F02.Value())
+			}()
+		}
+
+		wg.Wait()
 	})
 }

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -1906,9 +1906,9 @@ func TestComposit_concurrency(t *testing.T) {
 		composite := NewComposite(tlvTestSpec)
 
 		wg := sync.WaitGroup{}
-		wg.Add(5)
 
 		for i := 0; i < 5; i++ {
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 

--- a/message.go
+++ b/message.go
@@ -302,7 +302,6 @@ func (m *Message) unpack(src []byte) error {
 	return nil
 }
 
-// TODO: protect against concurrent access
 func (m *Message) MarshalJSON() ([]byte, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/message.go
+++ b/message.go
@@ -39,7 +39,7 @@ type Message struct {
 func NewMessage(spec *MessageSpec) *Message {
 	// Validate the spec
 	if err := spec.Validate(); err != nil {
-		panic(err) // as specs moslty static, we panic on spec validation errors
+		panic(err) //nolint:forbidigo,nolintlint // as specs moslty static, we panic on spec validation errors
 	}
 
 	fields := spec.CreateMessageFields()

--- a/message.go
+++ b/message.go
@@ -39,7 +39,7 @@ type Message struct {
 func NewMessage(spec *MessageSpec) *Message {
 	// Validate the spec
 	if err := spec.Validate(); err != nil {
-		panic(err) //nolint // as specs moslty static, we panic on spec validation errors
+		panic(err) // as specs moslty static, we panic on spec validation errors
 	}
 
 	fields := spec.CreateMessageFields()

--- a/message_test.go
+++ b/message_test.go
@@ -3,8 +3,6 @@ package iso8583
 import (
 	"encoding/hex"
 	"encoding/json"
-	"log"
-	"net/http"
 	"reflect"
 	"sync"
 	"testing"
@@ -17,15 +15,9 @@ import (
 	"github.com/moov-io/iso8583/sort"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "net/http/pprof"
 )
 
 func TestMessage(t *testing.T) {
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
-
 	spec := &MessageSpec{
 		Fields: map[int]field.Field{
 			0: field.NewString(&field.Spec{

--- a/test/fuzz-reader/reader.go
+++ b/test/fuzz-reader/reader.go
@@ -40,7 +40,7 @@ func Fuzz(data []byte) int {
 
 	_, err = message.Pack()
 	if err != nil {
-		panic(fmt.Errorf("failed to pack unpacked message: %w", err))
+		panic(fmt.Errorf("failed to pack unpacked message: %w", err)) //nolint:forbidigo,nolintlint
 	}
 
 	return 1

--- a/test/fuzz-reader/reader.go
+++ b/test/fuzz-reader/reader.go
@@ -40,7 +40,7 @@ func Fuzz(data []byte) int {
 
 	_, err = message.Pack()
 	if err != nil {
-		panic(fmt.Errorf("failed to pack unpacked message: %w", err)) //nolint
+		panic(fmt.Errorf("failed to pack unpacked message: %w", err))
 	}
 
 	return 1


### PR DESCRIPTION
With this PR, we've enhanced the concurrency safety of the methods in `iso8583.Message` and `field.Composite`.

## Rationale

I encountered a data race when two goroutines executed `message.GetString(11)`. This happened because the GetString method did more than just returning a value — it also updated an internal map. This concurrent access led to the race condition.


## Assumptions on Concurrency:

* Individual field access (like `field.String`, `field.Numeric`) is not thread-safe. Concurrency safety is ensured at the `Message` and `Composite` levels. If external concurrent access to individual fields is necessary, users should manage it with appropriate synchronization mechanisms, such as a mutex.
* Concurrent access is expected to be infrequent. Given this, the overhead introduced by using a mutex within Message and Composite is likely to be minimal.

## Concerns

A potential solution to the data race I encountered would have been to simply eliminate the unnecessary map modification, thus making `GetXXX()` methods pure getters (which is also done in the PR). However, because the message is referenced via a pointer and has a combination of getters, setters, `Marshal`, and `Unmarshal` methods, it doesn't feel entirely safe to assume that access to these will always be sequential. So, enhancing concurrency safety seems like a guarded measure.