### PR TITLE
add missing int64 support for String field Unmarshal

### DIFF
--- a/field/string.go
+++ b/field/string.go
@@ -126,7 +126,7 @@ func (f *String) Unmarshal(v interface{}) error {
 		switch val.Kind() { //nolint:exhaustive
 		case reflect.String:
 			val.SetString(f.value)
-		case reflect.Int:
+		case reflect.Int, reflect.Int64:
 			i, err := strconv.Atoi(f.value)
 			if err != nil {
 				return fmt.Errorf("failed to convert string to int: %w", err)
@@ -150,6 +150,7 @@ func (f *String) Unmarshal(v interface{}) error {
 			return fmt.Errorf("failed to convert string to int64: %w", err)
 		}
 		*val = i
+
 	case *String:
 		val.value = f.value
 	default:

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -107,6 +107,16 @@ func TestStringFieldUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 123456, b)
 
+	var i64 int64
+	err = stringField.Unmarshal(&i64)
+	require.NoError(t, err)
+	require.Equal(t, int64(123456), i64)
+
+	el := reflect.ValueOf(&i64).Elem()
+	err = stringField.Unmarshal(el)
+	require.NoError(t, err)
+	require.Equal(t, int64(123456), el.Int())
+
 	refStrValue := reflect.ValueOf(&s).Elem()
 	err = stringField.Unmarshal(refStrValue)
 	require.NoError(t, err)


### PR DESCRIPTION
We forgot to handle the `int64` type when we `Unmarshal` field. The following code returned the error `unsupported reflect.Value type: int64`:
```go
	data := struct {
		MTI               string `index:"0"`
		TransactionAmount int64  `index:"4"`
	}
	err := msg.Unrashal(&data)
	// handle error
```