### PR TITLE
fix : noneprefixer did not return correct fixed len

### DIFF
--- a/field/numeric.go
+++ b/field/numeric.go
@@ -185,7 +185,7 @@ func (f *Numeric) Marshal(v any) error {
 		}
 		f.value = val
 	default:
-		return fmt.Errorf("data does not match require *Numeric or (int, *int, string, *string) type")
+		return fmt.Errorf("data does not match require *Numeric or (int64, *int64, string, *string) type")
 	}
 
 	return nil

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -185,7 +185,7 @@ func (f *Numeric) Marshal(v any) error {
 		}
 		f.value = val
 	default:
-		return fmt.Errorf("data does not match require *Numeric or (int64, *int64, string, *string) type")
+		return fmt.Errorf("data does not match require *Numeric or (int, *int, string, *string) type")
 	}
 
 	return nil

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -160,7 +160,7 @@ func TestNumericFieldMarshal(t *testing.T) {
 
 	err = numericField.Marshal([]byte("123456"))
 	require.Error(t, err)
-	require.Equal(t, "data does not match require *Numeric or (int64, *int64, string, *string) type", err.Error())
+	require.Equal(t, "data does not match require *Numeric or (int, *int, string, *string) type", err.Error())
 }
 
 func TestNumericFieldWithNotANumber(t *testing.T) {

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -160,7 +160,7 @@ func TestNumericFieldMarshal(t *testing.T) {
 
 	err = numericField.Marshal([]byte("123456"))
 	require.Error(t, err)
-	require.Equal(t, "data does not match require *Numeric or (int, *int, string, *string) type", err.Error())
+	require.Equal(t, "data does not match require *Numeric or (int64, *int64, string, *string) type", err.Error())
 }
 
 func TestNumericFieldWithNotANumber(t *testing.T) {

--- a/prefix/none.go
+++ b/prefix/none.go
@@ -12,7 +12,7 @@ func (p *nonePrefixer) EncodeLength(int, int) ([]byte, error) {
 }
 
 func (p *nonePrefixer) DecodeLength(fixLen int, data []byte) (int, int, error) {
-	return len(data), 0, nil
+	return fixLen, 0, nil
 }
 
 func (p *nonePrefixer) Inspect() string {

--- a/prefix/none.go
+++ b/prefix/none.go
@@ -12,7 +12,7 @@ func (p *nonePrefixer) EncodeLength(int, int) ([]byte, error) {
 }
 
 func (p *nonePrefixer) DecodeLength(fixLen int, data []byte) (int, int, error) {
-	return fixLen, 0, nil
+	return len(data), 0, nil
 }
 
 func (p *nonePrefixer) Inspect() string {


### PR DESCRIPTION
this pull request contains 2 fixes:
1. noneprefixer fixed was returning len(data) instead of fixed value
2. text edit: numeric field parses int64 not int


while i am here i have a question if the someone can answer:
 -> Aren't  Numeric Fields usually encoded in BCD?   

Nemric field pack method:  `data := []byte(strconv.FormatInt(f.value, 10))... `

should be  :  `data, _ := hex.DecodeString(strconv.FormatInt(f.value, 10))`

I know that you can set the Encoder in spec to BCD.  but I dont see the deference between using a String Field and Numeric Field.