### PR TITLE
fix fixed length check for ebcdic and bcd

### DIFF
--- a/prefix/bcd.go
+++ b/prefix/bcd.go
@@ -72,7 +72,7 @@ type bcdFixedPrefixer struct {
 }
 
 func (p *bcdFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
-	if dataLen > fixLen {
+	if dataLen != fixLen {
 		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
 	}
 

--- a/prefix/bcd_test.go
+++ b/prefix/bcd_test.go
@@ -84,5 +84,11 @@ func TestBCDFixedPrefixer_EncodeLengthValidation(t *testing.T) {
 
 	_, err := pref.EncodeLength(8, 12)
 
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "field length: 12 should be fixed: 8")
+
+	_, err = pref.EncodeLength(8, 6)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field length: 6 should be fixed: 8")
 }

--- a/prefix/ebcdic.go
+++ b/prefix/ebcdic.go
@@ -71,7 +71,7 @@ type ebcdicFixedPrefixer struct {
 }
 
 func (p *ebcdicFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
-	if dataLen > fixLen {
+	if dataLen != fixLen {
 		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
 	}
 

--- a/prefix/ebcdic_test.go
+++ b/prefix/ebcdic_test.go
@@ -84,5 +84,11 @@ func TestEBCDICFixedPrefixer_EncodeLengthValidation(t *testing.T) {
 
 	_, err := pref.EncodeLength(8, 12)
 
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "field length: 12 should be fixed: 8")
+
+	_, err = pref.EncodeLength(8, 6)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field length: 6 should be fixed: 8")
 }


### PR DESCRIPTION
Length was not correctly checked for the fixed prefix of the BCD and EBCDIC. Using shorter values doesn't return an error, while using longer ones does.

This PR fixes it.