### PR TITLE
Fix EBCDIC1047 prefixer description

### DIFF
--- a/prefix/ebcdic1047.go
+++ b/prefix/ebcdic1047.go
@@ -62,7 +62,7 @@ func (p *ebcdic1047Prefixer) DecodeLength(maxLen int, data []byte) (int, int, er
 }
 
 func (p *ebcdic1047Prefixer) Inspect() string {
-	return fmt.Sprintf("EBCDIC.%s", strings.Repeat("L", p.digits))
+	return fmt.Sprintf("EBCDIC1047.%s", strings.Repeat("L", p.digits))
 }
 
 type ebcdic1047FixedPrefixer struct{}
@@ -80,5 +80,5 @@ func (p *ebcdic1047FixedPrefixer) DecodeLength(fixLen int, data []byte) (int, in
 }
 
 func (p *ebcdic1047FixedPrefixer) Inspect() string {
-	return "EBCDIC.Fixed"
+	return "EBCDIC1047.Fixed"
 }

--- a/prefix/ebcdic1047_test.go
+++ b/prefix/ebcdic1047_test.go
@@ -420,9 +420,9 @@ func TestEBCDIC1047PrefixersDecodeErrors(t *testing.T) {
 
 func TestEBCDIC1047PrefixersInspect(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "EBCDIC.Fixed", EBCDIC1047.Fixed.Inspect())
-	require.Equal(t, "EBCDIC.L", EBCDIC1047.L.Inspect())
-	require.Equal(t, "EBCDIC.LL", EBCDIC1047.LL.Inspect())
-	require.Equal(t, "EBCDIC.LLL", EBCDIC1047.LLL.Inspect())
-	require.Equal(t, "EBCDIC.LLLL", EBCDIC1047.LLLL.Inspect())
+	require.Equal(t, "EBCDIC1047.Fixed", EBCDIC1047.Fixed.Inspect())
+	require.Equal(t, "EBCDIC1047.L", EBCDIC1047.L.Inspect())
+	require.Equal(t, "EBCDIC1047.LL", EBCDIC1047.LL.Inspect())
+	require.Equal(t, "EBCDIC1047.LLL", EBCDIC1047.LLL.Inspect())
+	require.Equal(t, "EBCDIC1047.LLLL", EBCDIC1047.LLLL.Inspect())
 }


### PR DESCRIPTION
I believe the EBCDIC1047 prefixer should have its own `Inspect` description, different from EBCDIC.