### PR TITLE
Add ability to remove Subfields from a Composite field

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -125,6 +125,20 @@ func (f *Composite) GetSubfields() map[string]Field {
 	return f.getSubfields()
 }
 
+// RemoveSubfield removed subfield by a tag name
+func (f *Composite) RemoveSubfield(indexTag string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, set := f.setSubfields[indexTag]; !set {
+		return errors.New("fieldTag '" + indexTag + "' is not present")
+	}
+
+	delete(f.setSubfields, indexTag)
+
+	return nil
+}
+
 // getSubfields returns the map of set sub fields, it should be called
 // only when the mutex is locked
 func (f *Composite) getSubfields() map[string]Field {


### PR DESCRIPTION
We have a challenging task of adding and cleaning up `subelements`. Adding a field works fine, but removing one is a bit tricky.

Currently, I’ve found two workarounds:
 - Using Marshal/Unmarshal with a cleaned-up struct.
 - Getting the subfields, removing the unneeded ones, packing back to bytes, and then unpacking into a original composite field.

Both methods are slow and somewhat complex.

This new feature allows for removing subelements in constant time (O(1)) by simply checking the `setSubfields` and deleting the field if it exists.