### PR TITLE
Enhance Track2 Data Implementation

### DIFF
--- a/field/bitmap.go
+++ b/field/bitmap.go
@@ -148,7 +148,7 @@ func (f *Bitmap) Marshal(v interface{}) error {
 	return nil
 }
 
-// Reset resets the bitmap to its initial state because of how message works,
+// Reset the bitmap to its initial state because of how message works,
 // Message need a way to initialize bitmap. That's why we set parameters to
 // their default values here like we do in constructor.
 func (f *Bitmap) Reset() {

--- a/field/composite.go
+++ b/field/composite.go
@@ -138,17 +138,17 @@ func (f *Composite) getSubfields() map[string]Field {
 // SetSpec validates the spec and creates new instances of Subfields defined
 // in the specification.
 // NOTE: Composite does not support padding on the base spec. Therefore, users
-// should only pass None or nil values for ths type. Passing any other value
+// should only pass None or nil values for this type. Passing any other value
 // will result in a panic.
 func (f *Composite) SetSpec(spec *Spec) {
 	if err := spec.Validate(); err != nil {
-		panic(err) //nolint:forbidigo,nolintlint // as specs moslty static, we panic on spec validation errors
+		panic(err) //nolint:forbidigo,nolintlint // as specs mostly static, we panic on spec validation errors
 	}
 	f.spec = spec
 
 	var sortFn sort.StringSlice
 
-	// When bitmap is defined, always order tags by int.
+	// When bitmap is not defined, always order tags by int.
 	if spec.Bitmap != nil {
 		sortFn = sort.StringsByInt
 	} else {

--- a/field/packer_unpacker.go
+++ b/field/packer_unpacker.go
@@ -90,16 +90,10 @@ func (p Track2Unpacker) Unpack(packedFieldValue []byte, spec *Spec) ([]byte, int
 		return nil, 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
-	// Peek and see if the first value is equal to the padding rune if set
-	// if it is, we need to increase the length to decode by 1
-	// This is because the packer will pad the value, but set the value length
-	// equal to the unpadded value length
-	if spec.Pad != nil {
-		b := spec.Pad.Inspect()
-		r := b[0]
-		if packedFieldValue[prefBytes] == r {
-			valueLength++
-		}
+	// if valueLength is odd we need to make it even to adjust for
+	// the padding in our Packer
+	if valueLength%2 != 0 {
+		valueLength++
 	}
 
 	// decode the value

--- a/field/packer_unpacker_test.go
+++ b/field/packer_unpacker_test.go
@@ -157,7 +157,13 @@ func TestTrack2Packer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fd := field.NewTrack2Value(tc.primaryAccountNumber, &tc.expirationDate, tc.serviceCode, tc.discretionaryData, field.WithSeparator(tc.separator))
+			fd := field.NewTrack2Value(
+				tc.primaryAccountNumber,
+				&tc.expirationDate,
+				tc.serviceCode,
+				tc.discretionaryData,
+				tc.separator,
+			)
 			fd.SetSpec(s)
 
 			packed, err := fd.Pack()

--- a/field/track1.go
+++ b/field/track1.go
@@ -45,7 +45,6 @@ func NewTrack1(spec *Spec) *Track1 {
 }
 
 func NewTrack1Value(
-	formatCode,
 	primaryAccountNumber,
 	name string,
 	expirationDate *time.Time,
@@ -54,7 +53,6 @@ func NewTrack1Value(
 	opts ...Track1Option,
 ) *Track1 {
 	t := &Track1{
-		FormatCode:           formatCode,
 		PrimaryAccountNumber: primaryAccountNumber,
 		Name:                 name,
 		ExpirationDate:       expirationDate,

--- a/field/track1.go
+++ b/field/track1.go
@@ -30,14 +30,6 @@ const (
 
 var track1Regex = regexp.MustCompile(`^([A-Z]{1})([0-9]{1,19})\^([^\^]{2,26})\^([0-9]{4}|\^)([0-9]{3}|\^)([^\?]+)$`)
 
-type Track1Option func(*Track1)
-
-func WithFormatCode(code string) Track1Option {
-	return func(t *Track1) {
-		t.FormatCode = code
-	}
-}
-
 func NewTrack1(spec *Spec) *Track1 {
 	return &Track1{
 		spec: spec,
@@ -49,8 +41,9 @@ func NewTrack1Value(
 	name string,
 	expirationDate *time.Time,
 	serviceCode,
-	discretionaryData string,
-	opts ...Track1Option,
+	discretionaryData,
+	formatCode string,
+	fixedLength bool,
 ) *Track1 {
 	t := &Track1{
 		PrimaryAccountNumber: primaryAccountNumber,
@@ -58,10 +51,8 @@ func NewTrack1Value(
 		ExpirationDate:       expirationDate,
 		ServiceCode:          serviceCode,
 		DiscretionaryData:    discretionaryData,
-	}
-
-	for _, opt := range opts {
-		opt(t)
+		FormatCode:           formatCode,
+		FixedLength:          fixedLength,
 	}
 
 	return t

--- a/field/track1.go
+++ b/field/track1.go
@@ -30,10 +30,43 @@ const (
 
 var track1Regex = regexp.MustCompile(`^([A-Z]{1})([0-9]{1,19})\^([^\^]{2,26})\^([0-9]{4}|\^)([0-9]{3}|\^)([^\?]+)$`)
 
+type Track1Option func(*Track1)
+
+func WithFormatCode(code string) Track1Option {
+	return func(t *Track1) {
+		t.FormatCode = code
+	}
+}
+
 func NewTrack1(spec *Spec) *Track1 {
 	return &Track1{
 		spec: spec,
 	}
+}
+
+func NewTrack1Value(
+	formatCode,
+	primaryAccountNumber,
+	name string,
+	expirationDate *time.Time,
+	serviceCode,
+	discretionaryData string,
+	opts ...Track1Option,
+) *Track1 {
+	t := &Track1{
+		FormatCode:           formatCode,
+		PrimaryAccountNumber: primaryAccountNumber,
+		Name:                 name,
+		ExpirationDate:       expirationDate,
+		ServiceCode:          serviceCode,
+		DiscretionaryData:    discretionaryData,
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
 }
 
 func (f *Track1) Spec() *Spec {

--- a/field/track2.go
+++ b/field/track2.go
@@ -29,14 +29,6 @@ const (
 
 var track2Regex = regexp.MustCompile(`^([0-9]{1,19})(=|D)([0-9]{4})([0-9]{3})([^?]+)$`)
 
-type Track2Option func(*Track2)
-
-func WithSeparator(sep string) Track2Option {
-	return func(t *Track2) {
-		t.Separator = sep
-	}
-}
-
 func NewTrack2(spec *Spec) *Track2 {
 	return &Track2{
 		spec: spec,
@@ -47,18 +39,15 @@ func NewTrack2Value(
 	primaryAccountNumber string,
 	expirationDate *time.Time,
 	serviceCode,
-	discretionaryData string,
-	opts ...Track2Option,
+	discretionaryData,
+	separator string,
 ) *Track2 {
 	t := &Track2{
 		PrimaryAccountNumber: primaryAccountNumber,
+		Separator:            separator,
 		ExpirationDate:       expirationDate,
 		ServiceCode:          serviceCode,
 		DiscretionaryData:    discretionaryData,
-	}
-
-	for _, opt := range opts {
-		opt(t)
 	}
 
 	return t

--- a/field/track2.go
+++ b/field/track2.go
@@ -29,10 +29,39 @@ const (
 
 var track2Regex = regexp.MustCompile(`^([0-9]{1,19})(=|D)([0-9]{4})([0-9]{3})([^?]+)$`)
 
+type Track2Option func(*Track2)
+
+func WithSeparator(sep string) Track2Option {
+	return func(t *Track2) {
+		t.Separator = sep
+	}
+}
+
 func NewTrack2(spec *Spec) *Track2 {
 	return &Track2{
 		spec: spec,
 	}
+}
+
+func NewTrack2Value(
+	primaryAccountNumber string,
+	expirationDate *time.Time,
+	serviceCode,
+	discretionaryData string,
+	opts ...Track2Option,
+) *Track2 {
+	t := &Track2{
+		PrimaryAccountNumber: primaryAccountNumber,
+		ExpirationDate:       expirationDate,
+		ServiceCode:          serviceCode,
+		DiscretionaryData:    discretionaryData,
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
 }
 
 func (f *Track2) Spec() *Spec {
@@ -180,6 +209,7 @@ func (f *Track2) pack() ([]byte, error) {
 	if len(f.ServiceCode) > 0 {
 		code = f.ServiceCode
 	}
+
 	separator := defaultSeparator
 	if f.Separator != "" {
 		separator = f.Separator

--- a/field/track_test.go
+++ b/field/track_test.go
@@ -147,16 +147,18 @@ func TestTrack1(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
+			fd := field.NewTrack1Value(
+				"1234567890123445",
+				"PADILLA/L.",
+				&expDate,
+				"120",
+				"0000000000000**XXX******",
+				"B",
+				true,
+			)
+
 			track := field.NewTrack1(track1Spec)
-			err = track.Marshal(&field.Track1{
-				FixedLength:          true,
-				FormatCode:           "B",
-				PrimaryAccountNumber: "1234567890123445",
-				ServiceCode:          "120",
-				DiscretionaryData:    "0000000000000**XXX******",
-				ExpirationDate:       &expDate,
-				Name:                 "PADILLA/L.",
-			})
+			err = track.Marshal(fd)
 			require.NoError(t, err)
 
 			data := &field.Track1{}

--- a/field/track_test.go
+++ b/field/track_test.go
@@ -1,4 +1,4 @@
-package field
+package field_test
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/field"
 	"github.com/moov-io/iso8583/prefix"
 	"github.com/stretchr/testify/require"
 )
@@ -22,26 +23,28 @@ type TestSample struct {
 }
 
 var (
-	track1Spec = &Spec{
+	track1Spec = &field.Spec{
 		Length:      76,
 		Description: "Track 1 Data",
 		Enc:         encoding.ASCII,
 		Pref:        prefix.ASCII.LL,
 	}
 
-	track2Spec = &Spec{
+	track2Spec = &field.Spec{
 		Length:      37,
 		Description: "Track 2 Data",
 		Enc:         encoding.ASCII,
 		Pref:        prefix.ASCII.LL,
 	}
 
-	track3Spec = &Spec{
+	track3Spec = &field.Spec{
 		Length:      104,
 		Description: "Track 3 Data",
 		Enc:         encoding.ASCII,
 		Pref:        prefix.ASCII.LLL,
 	}
+
+	expiryDateFormat = "0601"
 )
 
 func TestTrack1(t *testing.T) {
@@ -77,7 +80,7 @@ func TestTrack1(t *testing.T) {
 			},
 		}
 
-		testTrackFields := func(t *testing.T, track *Track1, sample TestSample) {
+		testTrackFields := func(t *testing.T, track *field.Track1, sample TestSample) {
 			require.Equal(t, sample.FormatCode, track.FormatCode)
 			require.Equal(t, sample.PrimaryAccountNumber, track.PrimaryAccountNumber)
 			require.Equal(t, sample.ServiceCode, track.ServiceCode)
@@ -92,13 +95,13 @@ func TestTrack1(t *testing.T) {
 
 		for id, sample := range samples {
 			t.Run(fmt.Sprintf("sample %d", id), func(t *testing.T) {
-				spec := &Spec{
+				spec := &field.Spec{
 					Length:      76,
 					Description: "Track 1 Data",
 					Enc:         encoding.ASCII,
 					Pref:        prefix.ASCII.LL,
 				}
-				track := NewTrack1(spec)
+				track := field.NewTrack1(spec)
 				require.NotNil(t, track.Spec())
 
 				// test SetBytes / Bytes
@@ -117,7 +120,7 @@ func TestTrack1(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, packBuf, len(sample.Raw)+2, "packed length must be 2 bytes longer as it has ASCII.LL prefix")
 
-				unpackedTrack := NewTrack1(spec)
+				unpackedTrack := field.NewTrack1(spec)
 				require.NoError(t, err)
 
 				_, err = unpackedTrack.Unpack(packBuf)
@@ -125,7 +128,6 @@ func TestTrack1(t *testing.T) {
 
 				testTrackFields(t, unpackedTrack, sample)
 			})
-
 		}
 	})
 
@@ -136,8 +138,8 @@ func TestTrack1(t *testing.T) {
 		)
 
 		t.Run("Returns an error on mismatch of track type", func(t *testing.T) {
-			track := NewTrack1(track1Spec)
-			err := track.Marshal(NewStringValue("hello"))
+			track := field.NewTrack1(track1Spec)
+			err := track.Marshal(field.NewStringValue("hello"))
 			require.EqualError(t, err, "unsupported type: expected *Track1, got *field.String")
 		})
 
@@ -145,8 +147,8 @@ func TestTrack1(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
-			track := NewTrack1(track1Spec)
-			err = track.Marshal(&Track1{
+			track := field.NewTrack1(track1Spec)
+			err = track.Marshal(&field.Track1{
 				FixedLength:          true,
 				FormatCode:           "B",
 				PrimaryAccountNumber: "1234567890123445",
@@ -157,7 +159,7 @@ func TestTrack1(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			data := &Track1{}
+			data := &field.Track1{}
 
 			err = track.Unmarshal(data)
 
@@ -174,7 +176,7 @@ func TestTrack1(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
-			data := &Track1{
+			data := &field.Track1{
 				FixedLength:          true,
 				FormatCode:           "B",
 				PrimaryAccountNumber: "1234567890123445",
@@ -184,7 +186,7 @@ func TestTrack1(t *testing.T) {
 				Name:                 "PADILLA/L.",
 			}
 
-			track := NewTrack1(track1Spec)
+			track := field.NewTrack1(track1Spec)
 			err = track.Marshal(data)
 			require.NoError(t, err)
 
@@ -205,9 +207,9 @@ func TestTrack1(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
-			data := &Track1{}
+			data := &field.Track1{}
 
-			track := NewTrack1(track1Spec)
+			track := field.NewTrack1(track1Spec)
 			err = track.Marshal(data)
 			require.NoError(t, err)
 
@@ -227,9 +229,9 @@ func TestTrack1(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
-			data := &Track1{}
+			data := &field.Track1{}
 
-			track := NewTrack1(track1Spec)
+			track := field.NewTrack1(track1Spec)
 			err = track.Marshal(data)
 			require.NoError(t, err)
 
@@ -272,7 +274,7 @@ func TestTrack2TypedAPI(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
-			tracker := NewTrack2(track2Spec)
+			tracker := field.NewTrack2(track2Spec)
 			require.NotNil(t, tracker.Spec())
 
 			err := tracker.SetBytes(tc.Bytes)
@@ -303,8 +305,8 @@ func TestTrack2TypedAPI(t *testing.T) {
 
 	t.Run("Track 2 typed", func(t *testing.T) {
 		t.Run("Returns an error on mismatch of track type", func(t *testing.T) {
-			track := NewTrack2(track2Spec)
-			err := track.Marshal(NewStringValue("hello"))
+			track := field.NewTrack2(track2Spec)
+			err := track.Marshal(field.NewStringValue("hello"))
 			require.EqualError(t, err, "unsupported type: expected *Track2, got *field.String")
 		})
 
@@ -312,8 +314,8 @@ func TestTrack2TypedAPI(t *testing.T) {
 			expDate, err := time.Parse("0601", "9901")
 			require.NoError(t, err)
 
-			track := NewTrack2(track2Spec)
-			err = track.Marshal(&Track2{
+			track := field.NewTrack2(track2Spec)
+			err = track.Marshal(&field.Track2{
 				PrimaryAccountNumber: "4000340000000506",
 				Separator:            "D",
 				ServiceCode:          "111",
@@ -322,7 +324,7 @@ func TestTrack2TypedAPI(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			data := &Track2{}
+			data := &field.Track2{}
 
 			err = track.Unmarshal(data)
 
@@ -357,7 +359,7 @@ func TestTrack2TypedAPI(t *testing.T) {
 				expDate, err := time.Parse("0601", "2512")
 				require.NoError(t, err)
 
-				data := &Track2{
+				data := &field.Track2{
 					PrimaryAccountNumber: `4000340000000506`,
 					Separator:            tc.Separator,
 					ServiceCode:          `111`,
@@ -365,7 +367,7 @@ func TestTrack2TypedAPI(t *testing.T) {
 					ExpirationDate:       &expDate,
 				}
 
-				track := NewTrack2(track2Spec)
+				track := field.NewTrack2(track2Spec)
 				err = track.Marshal(data)
 				require.NoError(t, err)
 
@@ -401,9 +403,9 @@ func TestTrack2TypedAPI(t *testing.T) {
 				expDate, err := time.Parse("0601", "2512")
 				require.NoError(t, err)
 
-				data := &Track2{}
+				data := &field.Track2{}
 
-				track := NewTrack2(track2Spec)
+				track := field.NewTrack2(track2Spec)
 				err = track.Marshal(data)
 				require.NoError(t, err)
 
@@ -438,9 +440,9 @@ func TestTrack2TypedAPI(t *testing.T) {
 				expDate, err := time.Parse("0601", "2512")
 				require.NoError(t, err)
 
-				data := &Track2{}
+				data := &field.Track2{}
 
-				track := NewTrack2(track2Spec)
+				track := field.NewTrack2(track2Spec)
 				err = track.Marshal(data)
 				require.NoError(t, err)
 
@@ -475,13 +477,13 @@ func TestTrack3TypedAPI(t *testing.T) {
 			},
 		}
 		for _, sample := range samples {
-			spec := &Spec{
+			spec := &field.Spec{
 				Length:      104,
 				Description: "Track 3 Data",
 				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.LLL,
 			}
-			tracker := NewTrack3(spec)
+			tracker := field.NewTrack3(spec)
 			require.NotNil(t, tracker.Spec())
 
 			err := tracker.SetBytes([]byte(sample.Raw))
@@ -514,21 +516,21 @@ func TestTrack3TypedAPI(t *testing.T) {
 			rawWithPrefix = []byte("104011234567890123445=724724000000000****00300XXXX020200099010=********************==1=100000000000000000**")
 		)
 		t.Run("Returns an error on mismatch of track type", func(t *testing.T) {
-			track := NewTrack3(track3Spec)
-			err := track.Marshal(NewStringValue("hello"))
+			track := field.NewTrack3(track3Spec)
+			err := track.Marshal(field.NewStringValue("hello"))
 			require.EqualError(t, err, "unsupported type: expected *Track3, got *field.String")
 		})
 
 		t.Run("Unmarshal gets track values into data parameter", func(t *testing.T) {
-			track := NewTrack3(track3Spec)
-			err := track.Marshal(&Track3{
+			track := field.NewTrack3(track3Spec)
+			err := track.Marshal(&field.Track3{
 				FormatCode:           `01`,
 				PrimaryAccountNumber: `1234567890123445`,
 				DiscretionaryData:    `724724000000000****00300XXXX020200099010=********************==1=100000000000000000**`,
 			})
 			require.NoError(t, err)
 
-			data := &Track3{}
+			data := &field.Track3{}
 
 			err = track.Unmarshal(data)
 
@@ -539,13 +541,13 @@ func TestTrack3TypedAPI(t *testing.T) {
 		})
 
 		t.Run("Pack correctly serializes data to bytes", func(t *testing.T) {
-			data := &Track3{
+			data := &field.Track3{
 				FormatCode:           `01`,
 				PrimaryAccountNumber: `1234567890123445`,
 				DiscretionaryData:    `724724000000000****00300XXXX020200099010=********************==1=100000000000000000**`,
 			}
 
-			track := NewTrack3(track3Spec)
+			track := field.NewTrack3(track3Spec)
 			err := track.Marshal(data)
 			require.NoError(t, err)
 
@@ -560,9 +562,9 @@ func TestTrack3TypedAPI(t *testing.T) {
 		})
 
 		t.Run("Unpack correctly deserializes bytes with length prefix to the data struct", func(t *testing.T) {
-			data := &Track3{}
+			data := &field.Track3{}
 
-			track := NewTrack3(track3Spec)
+			track := field.NewTrack3(track3Spec)
 			err := track.Marshal(data)
 			require.NoError(t, err)
 
@@ -576,9 +578,9 @@ func TestTrack3TypedAPI(t *testing.T) {
 		})
 
 		t.Run("SetBytes correctly deserializes and assigns data", func(t *testing.T) {
-			data := &Track3{}
+			data := &field.Track3{}
 
-			track := NewTrack3(track3Spec)
+			track := field.NewTrack3(track3Spec)
 			err := track.Marshal(data)
 			require.NoError(t, err)
 


### PR DESCRIPTION
This adds:
- `NewTrack1Value` and `NewTrack2Value` functions to construct track1 and track2 data. This mirrors what we have implemented for other fields
- Adds option functions to above constructors to change the default values during packing
- Adds `Track2Packer` and `Track2Unpacker` to handle some custom packing/unpacking for certain networks
- Adds tests for the packing logic

This fixes:
- a few comment errors I noticed while in the code base