### PR TITLE
fix: generate length prefix with encoded data

### DIFF
--- a/field/packer_unpacker.go
+++ b/field/packer_unpacker.go
@@ -20,7 +20,7 @@ func (p defaultPacker) Pack(value []byte, spec *Spec) ([]byte, error) {
 	}
 
 	// encode the length
-	lengthPrefix, err := spec.Pref.EncodeLength(spec.Length, len(value))
+	lengthPrefix, err := spec.Pref.EncodeLength(spec.Length, len(encodedValue))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}
@@ -73,7 +73,7 @@ func (p Track2Packer) Pack(value []byte, spec *Spec) ([]byte, error) {
 
 	// Encode the length to that of the original string, not the potentially
 	// padded length
-	packedLength, err := spec.Pref.EncodeLength(spec.Length, len(value))
+	packedLength, err := spec.Pref.EncodeLength(spec.Length, len(packed))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode length: %w", err)
 	}

--- a/field/packer_unpacker_test.go
+++ b/field/packer_unpacker_test.go
@@ -184,3 +184,24 @@ func TestTrack2Packer(t *testing.T) {
 		})
 	}
 }
+
+func TestPackerandUnpackerWithVariantDataLength(t *testing.T) {
+	spec := &field.Spec{
+		Length:      5,
+		Description: "Field",
+		Enc:         encoding.EBCDIC1047,
+		Pref:        prefix.EBCDIC1047.L,
+	}
+
+	data := []byte{0xc2, 0xa0, 0x31}
+	str := field.NewString(spec)
+	str.SetBytes(data)
+
+	packed, err := str.Pack()
+	require.NoError(t, err)
+	require.Equal(t, 0xf2, packed[0])
+
+	_, err = str.Unpack(packed)
+	require.NoError(t, err)
+	require.Equal(t, data, str.Bytes())
+}


### PR DESCRIPTION
# Problem

While dealing with the EBCDIC1047 encoding, some characters can be decoded from 1 byte to 2 bytes. It can cause an issue with the message packing.
For instance, [this](https://cs.opensource.google/go/x/text/+/refs/tags/v0.16.0:encoding/charmap/tables.go;l=1977) decodes EBCDIC1047 to UTF-8. it will transform `65` (0x41) to 2 bytes `(0xc2, 0xa0)`.

When we pack this data again, the data length we got is 2 instead of 1.

# How to reproduce

```golang
	spec := &field.Spec{
		Length:      5,
		Description: "Field",
		Enc:         encoding.EBCDIC1047,
		Pref:        prefix.EBCDIC1047.L,
	}

	str := field.NewString(spec)
	str.SetBytes([]byte{194, 160, 49})
	packed, err := str.Pack()
	size, err := str.Unpack(packed)
```
the Unpack will fail with the error `failed to decode content: not enough data to decode. expected len 3, got 2`.

Because the str.Pack() encode `3` as length prefix. The actual representation in EBCDIC1047 of `[]byte{194, 160, 49}` has only 2 bytes `(0x41, 0xf1)`

# How to fix

Encode the length prefix with encoded data, instead of original data.






