### PR TITLE
Standardized error messages across iso8583 prefixers

### DIFF
--- a/describe.go
+++ b/describe.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -36,7 +37,7 @@ func (m *MessageWrapper) GetSubfields() map[string]field.Field {
 	fields := m.Message.GetFields()
 	result := make(map[string]field.Field, len(fields))
 	for k, v := range fields {
-		result[fmt.Sprintf("%d", k)] = v
+		result[strconv.Itoa(k)] = v
 	}
 	return result
 }

--- a/field_filter.go
+++ b/field_filter.go
@@ -1,7 +1,7 @@
 package iso8583
 
 import (
-	"fmt"
+	"errors"
 	"unicode/utf8"
 
 	"github.com/moov-io/iso8583/field"
@@ -18,6 +18,8 @@ const (
 	panLastIndex  = 4
 	panPattern    = "****"
 )
+
+var ErrCreatingNewTrackData = errors.New("creating new track data")
 
 type FilterFunc func(in string, data field.Field) string
 
@@ -109,7 +111,7 @@ func newTrackData(data, track field.Field) error {
 	if raw, err := data.Pack(); err == nil {
 		track.SetSpec(data.Spec())
 		if _, err := track.Unpack(raw); err != nil {
-			return fmt.Errorf("creating new track data")
+			return ErrCreatingNewTrackData
 		}
 	}
 

--- a/message.go
+++ b/message.go
@@ -318,7 +318,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	fieldMap := m.getFields()
 	strFieldMap := map[string]field.Field{}
 	for id, field := range fieldMap {
-		strFieldMap[fmt.Sprint(id)] = field
+		strFieldMap[strconv.Itoa(id)] = field
 	}
 
 	// get only fields that were set

--- a/message_spec_test.go
+++ b/message_spec_test.go
@@ -30,8 +30,8 @@ func TestMessageSpec_CreateMessageFields(t *testing.T) {
 	fields := spec.CreateMessageFields()
 
 	// test that derived fields have the same type as in the message spec
-	require.True(t, reflect.TypeOf(fields[0]).Elem() == reflect.TypeOf(field.String{}))
-	require.True(t, reflect.TypeOf(fields[1]).Elem() == reflect.TypeOf(field.Bitmap{}))
+	require.Equal(t, reflect.TypeOf(field.String{}), reflect.TypeOf(fields[0]).Elem())
+	require.Equal(t, reflect.TypeOf(field.Bitmap{}), reflect.TypeOf(fields[1]).Elem())
 
 	// test that derived field have the same spec
 	require.Equal(t, fields[0].Spec(), spec.Fields[0].Spec())

--- a/message_test.go
+++ b/message_test.go
@@ -903,7 +903,7 @@ func TestPackUnpack(t *testing.T) {
 		require.Error(t, err)
 		var unpackError *iso8583errors.UnpackError
 		require.ErrorAs(t, err, &unpackError)
-		assert.Equal(t, unpackError.FieldID, "120")
+		assert.Equal(t, "120", unpackError.FieldID)
 
 		s, err := message.GetString(2)
 		require.NoError(t, err)

--- a/prefix/ascii.go
+++ b/prefix/ascii.go
@@ -22,11 +22,11 @@ var ASCII = Prefixers{
 
 func (p *asciiVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	if len(strconv.Itoa(dataLen)) > p.Digits {
-		return nil, fmt.Errorf("number of digits in length: %d exceeds: %d", dataLen, p.Digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.Digits)
 	}
 
 	res := fmt.Sprintf("%0*d", p.Digits, dataLen)
@@ -36,7 +36,7 @@ func (p *asciiVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 
 func (p *asciiVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	if len(data) < p.Digits {
-		return 0, 0, fmt.Errorf("not enough data length: %d to read: %d byte digits", len(data), p.Digits)
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, len(data), p.Digits)
 	}
 
 	dataLen, err := strconv.Atoi(string(data[:p.Digits]))
@@ -46,11 +46,11 @@ func (p *asciiVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, erro
 
 	// length should be positive
 	if dataLen < 0 {
-		return 0, 0, fmt.Errorf("invalid length: %d", dataLen)
+		return 0, 0, fmt.Errorf(invalidLength, dataLen)
 	}
 
 	if dataLen > maxLen {
-		return 0, 0, fmt.Errorf("data length: %d is larger than maximum %d", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, p.Digits, nil
@@ -65,7 +65,7 @@ type asciiFixedPrefixer struct {
 
 func (p *asciiFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	if dataLen != fixLen {
-		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen)
 	}
 
 	return []byte{}, nil

--- a/prefix/bcd.go
+++ b/prefix/bcd.go
@@ -25,11 +25,11 @@ var BCD = Prefixers{
 
 func (p *bcdVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	if len(strconv.Itoa(dataLen)) > p.Digits {
-		return nil, fmt.Errorf("number of digits in length: %d exceeds: %d", dataLen, p.Digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.Digits)
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.Digits, dataLen)
@@ -44,7 +44,7 @@ func (p *bcdVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 func (p *bcdVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	length := bcd.EncodedLen(p.Digits)
 	if len(data) < length {
-		return 0, 0, fmt.Errorf("length mismatch: want to read %d bytes, get only %d", length, len(data))
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, length, len(data))
 	}
 
 	bDigits, _, err := encoding.BCD.Decode(data[:length], p.Digits)
@@ -58,7 +58,7 @@ func (p *bcdVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error)
 	}
 
 	if dataLen > maxLen {
-		return 0, 0, fmt.Errorf("data length %d is larger than maximum %d", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, length, nil
@@ -73,7 +73,7 @@ type bcdFixedPrefixer struct {
 
 func (p *bcdFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	if dataLen != fixLen {
-		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen)
 	}
 
 	return []byte{}, nil

--- a/prefix/bcd_test.go
+++ b/prefix/bcd_test.go
@@ -21,7 +21,7 @@ func TestBCDVarPrefixer_EncodeLengthMaxLengthValidation(t *testing.T) {
 func TestBCDVarPrefixer_DecodeLengthMaxLengthValidation(t *testing.T) {
 	_, _, err := BCD.LLL.DecodeLength(20, []byte{0x22})
 
-	require.Contains(t, err.Error(), "length mismatch: want to read 2 bytes, get only 1")
+	require.Contains(t, err.Error(), "not enough data length: 2 to read: 1 byte digits")
 }
 
 func TestBCDVarPrefixer_LHelpers(t *testing.T) {

--- a/prefix/bertlv.go
+++ b/prefix/bertlv.go
@@ -36,7 +36,7 @@ func (p *berTLVPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	// checking maxLen for a 0 is a way to disable check and also support
 	// backwards compatibility with the old contract that didn't have maxLen
 	if maxLen != 0 && dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	buf := big.NewInt(int64(dataLen)).Bytes()
@@ -67,7 +67,7 @@ func (p *berTLVPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error)
 		// checking maxLen for a 0 is a way to disable check and also support
 		// backwards compatibility with the old contract that didn't have maxLen
 		if maxLen != 0 && dataLen > maxLen {
-			return 0, read, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+			return 0, read, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 		}
 
 		return dataLen, read, nil
@@ -85,7 +85,7 @@ func (p *berTLVPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error)
 	// checking maxLen for a 0 is a way to disable check and also support
 	// backwards compatibility with the old contract that didn't have maxLen
 	if maxLen != 0 && dataLen > maxLen {
-		return 0, read, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return 0, read, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, read, nil

--- a/prefix/binary.go
+++ b/prefix/binary.go
@@ -22,7 +22,7 @@ type binaryFixedPrefixer struct {
 
 func (p *binaryFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	if dataLen != fixLen {
-		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen)
 	}
 
 	return []byte{}, nil
@@ -64,7 +64,7 @@ func bytesToInt(b []byte) (int, error) {
 
 func (p *binaryVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	res, err := intToBytes(dataLen)
@@ -76,7 +76,7 @@ func (p *binaryVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	res = bytes.TrimLeft(res, "\x00")
 
 	if len(res) > p.Digits {
-		return nil, fmt.Errorf("number of digits in length: %d exceeds: %d", dataLen, p.Digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.Digits)
 	}
 
 	// if len of res is less than p.Digits prepend with 0x00
@@ -92,7 +92,7 @@ func (p *binaryVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 // and the number of bytes read.
 func (p *binaryVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	if len(data) < p.Digits {
-		return 0, 0, fmt.Errorf("not enough data length: %d to read: %d bytes", len(data), p.Digits)
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, len(data), p.Digits)
 	}
 
 	prefBytes := data[:p.Digits]
@@ -111,7 +111,7 @@ func (p *binaryVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, err
 	}
 
 	if dataLen > maxLen {
-		return 0, 0, fmt.Errorf("data length: %d is larger than maximum %d", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, p.Digits, nil

--- a/prefix/ebcdic.go
+++ b/prefix/ebcdic.go
@@ -24,11 +24,11 @@ var EBCDIC = Prefixers{
 
 func (p *ebcdicVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	if len(strconv.Itoa(dataLen)) > p.Digits {
-		return nil, fmt.Errorf("number of digits in length: %d exceeds: %d", dataLen, p.Digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.Digits)
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.Digits, dataLen)
@@ -43,7 +43,7 @@ func (p *ebcdicVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 func (p *ebcdicVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	length := p.Digits
 	if len(data) < length {
-		return 0, 0, fmt.Errorf("length mismatch: want to read %d bytes, get only %d", length, len(data))
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, length, len(data))
 	}
 
 	bDigits, _, err := encoding.EBCDIC.Decode(data[:length], p.Digits)
@@ -57,7 +57,7 @@ func (p *ebcdicVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, err
 	}
 
 	if dataLen > maxLen {
-		return 0, 0, fmt.Errorf("data length %d is larger than maximum %d", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, length, nil
@@ -72,7 +72,7 @@ type ebcdicFixedPrefixer struct {
 
 func (p *ebcdicFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	if dataLen != fixLen {
-		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen)
 	}
 
 	return []byte{}, nil

--- a/prefix/ebcdic1047.go
+++ b/prefix/ebcdic1047.go
@@ -24,11 +24,11 @@ type ebcdic1047Prefixer struct {
 
 func (p *ebcdic1047Prefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length [%d] is larger than maximum [%d]", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	if len(strconv.Itoa(dataLen)) > p.digits {
-		return nil, fmt.Errorf("number of digits in data [%d] exceeds its maximum indicator [%d]", dataLen, p.digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.digits)
 	}
 
 	strLen := fmt.Sprintf("%0*d", p.digits, dataLen)
@@ -41,7 +41,7 @@ func (p *ebcdic1047Prefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 
 func (p *ebcdic1047Prefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	if len(data) < p.digits {
-		return 0, 0, fmt.Errorf("not enough data length [%d] to read [%d] byte digits", len(data), p.digits)
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, len(data), p.digits)
 	}
 
 	decodedData, _, err := encoding.EBCDIC1047.Decode(data[:p.digits], p.digits)
@@ -55,7 +55,7 @@ func (p *ebcdic1047Prefixer) DecodeLength(maxLen int, data []byte) (int, int, er
 	}
 
 	if dataLen > maxLen {
-		return 0, 0, fmt.Errorf("data length [%d] is larger than maximum [%d]", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return dataLen, p.digits, nil
@@ -69,7 +69,7 @@ type ebcdic1047FixedPrefixer struct{}
 
 func (p *ebcdic1047FixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	if dataLen != fixLen {
-		return nil, fmt.Errorf("field length [%d] should be fixed [%d]", dataLen, fixLen)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen)
 	}
 
 	return []byte{}, nil

--- a/prefix/ebcdic1047_test.go
+++ b/prefix/ebcdic1047_test.go
@@ -123,25 +123,25 @@ func TestEBCDIC1047PrefixersEncodeErrors(t *testing.T) {
 				prefixer:      EBCDIC1047.L,
 				maxLen:        8,
 				dataLen:       9,
-				expectedError: "field length [9] is larger than maximum [8]",
+				expectedError: "field length: 9 is larger than maximum: 8",
 			},
 			{
 				prefixer:      EBCDIC1047.LL,
 				maxLen:        52,
 				dataLen:       73,
-				expectedError: "field length [73] is larger than maximum [52]",
+				expectedError: "field length: 73 is larger than maximum: 52",
 			},
 			{
 				prefixer:      EBCDIC1047.LLL,
 				maxLen:        512,
 				dataLen:       999,
-				expectedError: "field length [999] is larger than maximum [512]",
+				expectedError: "field length: 999 is larger than maximum: 512",
 			},
 			{
 				prefixer:      EBCDIC1047.LLLL,
 				maxLen:        1024,
 				dataLen:       2048,
-				expectedError: "field length [2048] is larger than maximum [1024]",
+				expectedError: "field length: 2048 is larger than maximum: 1024",
 			},
 		} {
 			encoded, err := testCase.prefixer.EncodeLength(testCase.maxLen, testCase.dataLen)
@@ -165,25 +165,25 @@ func TestEBCDIC1047PrefixersEncodeErrors(t *testing.T) {
 				prefixer:      EBCDIC1047.L,
 				maxLen:        52,
 				dataLen:       10,
-				expectedError: "number of digits in data [10] exceeds its maximum indicator [1]",
+				expectedError: "number of digits in length: 10 exceeds: 1",
 			},
 			{
 				prefixer:      EBCDIC1047.LL,
 				maxLen:        101,
 				dataLen:       100,
-				expectedError: "number of digits in data [100] exceeds its maximum indicator [2]",
+				expectedError: "number of digits in length: 100 exceeds: 2",
 			},
 			{
 				prefixer:      EBCDIC1047.LLL,
 				maxLen:        1333,
 				dataLen:       1001,
-				expectedError: "number of digits in data [1001] exceeds its maximum indicator [3]",
+				expectedError: "number of digits in length: 1001 exceeds: 3",
 			},
 			{
 				prefixer:      EBCDIC1047.LLLL,
 				maxLen:        11111,
 				dataLen:       10908,
-				expectedError: "number of digits in data [10908] exceeds its maximum indicator [4]",
+				expectedError: "number of digits in length: 10908 exceeds: 4",
 			},
 		} {
 			encoded, err := testCase.prefixer.EncodeLength(testCase.maxLen, testCase.dataLen)
@@ -196,7 +196,7 @@ func TestEBCDIC1047PrefixersEncodeErrors(t *testing.T) {
 		t.Parallel()
 		encoded, err := EBCDIC1047.Fixed.EncodeLength(128, 127)
 		require.Nil(t, encoded)
-		require.EqualError(t, err, "field length [127] should be fixed [128]")
+		require.EqualError(t, err, "field length: 127 should be fixed: 128")
 	})
 }
 
@@ -309,25 +309,25 @@ func TestEBCDIC1047PrefixersDecodeErrors(t *testing.T) {
 				prefixer:      EBCDIC1047.L,
 				maxLen:        8,
 				data:          []byte{},
-				expectedError: "not enough data length [0] to read [1] byte digits",
+				expectedError: "not enough data length: 0 to read: 1 byte digits",
 			},
 			{
 				prefixer:      EBCDIC1047.LL,
 				maxLen:        16,
 				data:          []byte{ebcdic1047_8},
-				expectedError: "not enough data length [1] to read [2] byte digits",
+				expectedError: "not enough data length: 1 to read: 2 byte digits",
 			},
 			{
 				prefixer:      EBCDIC1047.LLL,
 				maxLen:        128,
 				data:          []byte{ebcdic1047_0, ebcdic1047_0},
-				expectedError: "not enough data length [2] to read [3] byte digits",
+				expectedError: "not enough data length: 2 to read: 3 byte digits",
 			},
 			{
 				prefixer:      EBCDIC1047.LLLL,
 				maxLen:        8,
 				data:          []byte{ebcdic1047_0, ebcdic1047_0, ebcdic1047_9},
-				expectedError: "not enough data length [3] to read [4] byte digits",
+				expectedError: "not enough data length: 3 to read: 4 byte digits",
 			},
 		} {
 			length, read, err := testCase.prefixer.DecodeLength(testCase.maxLen, testCase.data)
@@ -349,25 +349,25 @@ func TestEBCDIC1047PrefixersDecodeErrors(t *testing.T) {
 				prefixer:      EBCDIC1047.L,
 				maxLen:        8,
 				data:          []byte{ebcdic1047_9},
-				expectedError: "data length [9] is larger than maximum [8]",
+				expectedError: "data length: 9 is larger than maximum 8",
 			},
 			{
 				prefixer:      EBCDIC1047.LL,
 				maxLen:        16,
 				data:          []byte{ebcdic1047_2, ebcdic1047_0},
-				expectedError: "data length [20] is larger than maximum [16]",
+				expectedError: "data length: 20 is larger than maximum 16",
 			},
 			{
 				prefixer:      EBCDIC1047.LLL,
 				maxLen:        128,
 				data:          []byte{ebcdic1047_1, ebcdic1047_9, ebcdic1047_4},
-				expectedError: "data length [194] is larger than maximum [128]",
+				expectedError: "data length: 194 is larger than maximum 128",
 			},
 			{
 				prefixer:      EBCDIC1047.LLLL,
 				maxLen:        8000,
 				data:          []byte{ebcdic1047_8, ebcdic1047_0, ebcdic1047_9, ebcdic1047_2},
-				expectedError: "data length [8092] is larger than maximum [8000]",
+				expectedError: "data length: 8092 is larger than maximum 8000",
 			},
 		} {
 			length, read, err := testCase.prefixer.DecodeLength(testCase.maxLen, testCase.data)

--- a/prefix/ebcdic_test.go
+++ b/prefix/ebcdic_test.go
@@ -21,7 +21,7 @@ func TestEBCDICVarPrefixer_EncodeLengthMaxLengthValidation(t *testing.T) {
 func TestEBCDICVarPrefixer_DecodeLengthMaxLengthValidation(t *testing.T) {
 	_, _, err := EBCDIC.LLL.DecodeLength(20, []byte{0x22})
 
-	require.Contains(t, err.Error(), "length mismatch: want to read 3 bytes, get only 1")
+	require.Contains(t, err.Error(), "not enough data length: 3 to read: 1 byte digits")
 }
 
 func TestEBCDICVarPrefixer_LHelpers(t *testing.T) {

--- a/prefix/error.go
+++ b/prefix/error.go
@@ -1,0 +1,8 @@
+package prefix
+
+const fieldLengthIsLargerThanMax = "field length: %d is larger than maximum: %d"
+const numberOfDigitsInLengthExceeds = "number of digits in length: %d exceeds: %d"
+const notEnoughDataToRead = "not enough data length: %d to read: %d byte digits"
+const invalidLength = "invalid length: %d"
+const dataLengthIsLargerThanMax = "data length: %d is larger than maximum %d"
+const fieldLengthShouldBeFixed = "field length: %d should be fixed: %d"

--- a/prefix/hex.go
+++ b/prefix/hex.go
@@ -23,7 +23,7 @@ type hexFixedPrefixer struct {
 func (p *hexFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	// for ascii hex the length is x2 (ascii hex digit takes one byte)
 	if dataLen != fixLen*2 {
-		return nil, fmt.Errorf("field length: %d should be fixed: %d", dataLen, fixLen*2)
+		return nil, fmt.Errorf(fieldLengthShouldBeFixed, dataLen, fixLen*2)
 	}
 
 	return []byte{}, nil
@@ -43,12 +43,12 @@ type hexVarPrefixer struct {
 
 func (p *hexVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 	if dataLen > maxLen {
-		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+		return nil, fmt.Errorf(fieldLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	maxPossibleLength := 1<<(p.Digits*8) - 1
 	if dataLen > maxPossibleLength {
-		return nil, fmt.Errorf("number of digits in length: %d exceeds: %d", dataLen, p.Digits)
+		return nil, fmt.Errorf(numberOfDigitsInLengthExceeds, dataLen, p.Digits)
 	}
 
 	strLen := strconv.FormatInt(int64(dataLen), 16)
@@ -60,7 +60,7 @@ func (p *hexVarPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
 func (p *hexVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
 	length := hex.EncodedLen(p.Digits)
 	if len(data) < length {
-		return 0, 0, fmt.Errorf("length mismatch: want to read %d bytes, get only %d", length, len(data))
+		return 0, 0, fmt.Errorf(notEnoughDataToRead, length, len(data))
 	}
 
 	dataLen, err := strconv.ParseInt(string(data[:length]), 16, p.Digits*8)
@@ -69,7 +69,7 @@ func (p *hexVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error)
 	}
 
 	if int(dataLen) > maxLen {
-		return 0, 0, fmt.Errorf("data length %d is larger than maximum %d", dataLen, maxLen)
+		return 0, 0, fmt.Errorf(dataLengthIsLargerThanMax, dataLen, maxLen)
 	}
 
 	return int(dataLen), length, nil


### PR DESCRIPTION
This PR standardizes error messages across the iso8583 prefixer to ensure consistency and maintainability. Previously, error messages were defined in various places with inconsistent wording and formatting. This update unifies them using a structured approach, making them easier to reference, log, and test.