### PR TITLE
Support marshaling named string types

### DIFF
--- a/field/string.go
+++ b/field/string.go
@@ -147,7 +147,10 @@ func (f *String) Marshal(v interface{}) error {
 	if v == nil {
 		f.value = ""
 		return nil
-	} else if reflect.ValueOf(v).IsZero() {
+	}
+
+	rv := reflect.ValueOf(v)
+	if rv.IsZero() {
 		if !strings.Contains(reflect.ValueOf(v).Type().String(), "int") {
 			f.value = ""
 			return nil
@@ -178,7 +181,18 @@ func (f *String) Marshal(v interface{}) error {
 			f.value = strconv.FormatInt(*v, 10)
 		}
 	default:
-		return fmt.Errorf("data does not match required *String or (string, *string, int, *int) type")
+		kind := rv.Kind()
+		if kind == reflect.Ptr {
+			rv = rv.Elem()
+			kind = rv.Kind()
+		}
+
+		switch kind {
+		case reflect.String:
+			f.value = rv.String()
+		default:
+			return fmt.Errorf("data does not match required *String or (string, *string, int, *int) type")
+		}
 	}
 
 	return nil

--- a/message_test.go
+++ b/message_test.go
@@ -2179,6 +2179,8 @@ func TestStructWithTypes(t *testing.T) {
 		},
 	}
 
+	type myString string
+
 	t.Run("pack", func(t *testing.T) {
 		panInt := 4242424242424242
 		panStr := "4242424242424242"
@@ -2222,6 +2224,19 @@ func TestStructWithTypes(t *testing.T) {
 					MTI: "0110",
 				},
 				expectedPackedString: "01104000000000000000000000000000000000",
+			},
+
+			// Tests for named string type
+			{
+				name: "struct with named string type and value set",
+				input: struct {
+					MTI                  myString `index:"0"`
+					PrimaryAccountNumber myString `index:"2"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: myString(panStr),
+				},
+				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
 			},
 
 			// Tests for *string type
@@ -2439,6 +2454,15 @@ func TestStructWithTypes(t *testing.T) {
 				input: &struct {
 					MTI                  string `index:"0"`
 					PrimaryAccountNumber string `index:"2,keepzero"`
+				}{},
+			},
+
+			// Tests for named string type
+			{
+				name: "struct with named string type",
+				input: &struct {
+					MTI                  myString `index:"0"`
+					PrimaryAccountNumber myString `index:"2"`
 				}{},
 			},
 


### PR DESCRIPTION
IMHO types like `type myString string` should also be considered as a `string` when marshaling. Unmarshaling already does this.