### PR TITLE
Composite.Unpack shouldn't err if its bitmap is empty

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -311,6 +311,10 @@ func (f *Composite) Unpack(data []byte) (int, error) {
 		return 0, fmt.Errorf("failed to decode length: %w", err)
 	}
 
+	if dataLen == 0 {
+		return 0, nil
+	}
+
 	isVariableLength := false
 	if offset != 0 {
 		isVariableLength = true

--- a/message_test.go
+++ b/message_test.go
@@ -1324,6 +1324,7 @@ func TestPackUnpack(t *testing.T) {
 		want := "303130306000000000000000323200"
 
 		rawWant, err := hex.DecodeString(want)
+		require.NoError(t, err)
 
 		msg2Unpack := NewMessage(compositeSpec)
 		err = msg2Unpack.Unpack(rawWant)


### PR DESCRIPTION
I've encountered messages in the wild that seem to have a composite field present but with length 0. This PR is my best attempt at recreating one in a test and fixing it too.

You can probably write a better test case inside `composite_test.go` but I wasn't able to.