### PR TITLE
Fix DecodeLength() for long values in variable length HEX field

### DIFF
--- a/prefix/hex.go
+++ b/prefix/hex.go
@@ -29,7 +29,7 @@ func (p *hexFixedPrefixer) EncodeLength(fixLen, dataLen int) ([]byte, error) {
 	return []byte{}, nil
 }
 
-func (p *hexFixedPrefixer) DecodeLength(fixLen int, data []byte) (int, int, error) {
+func (p *hexFixedPrefixer) DecodeLength(fixLen int, _ []byte) (int, int, error) {
 	return fixLen, 0, nil
 }
 
@@ -63,7 +63,7 @@ func (p *hexVarPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error)
 		return 0, 0, fmt.Errorf(notEnoughDataToRead, length, len(data))
 	}
 
-	dataLen, err := strconv.ParseInt(string(data[:length]), 16, p.Digits*8)
+	dataLen, err := strconv.ParseUint(string(data[:length]), 16, p.Digits*8)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/prefix/hex_test.go
+++ b/prefix/hex_test.go
@@ -114,6 +114,19 @@ func Test_hexVarPrefixer_DecodeLength(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name: "data_length_exceeds_signed_byte",
+			fields: fields{
+				Digits: 1,
+			},
+			args: args{
+				maxLen: 255,
+				data:   []byte("FFzdsadsdasdsdasasdasadadasdasdsafsdgerherhrtherherhwergewrergtertwetwegwhrwehjerjetuery4wtwegwrjerjrejereryereye4y45735u45u45ehe45yy4t34t34y4y43h34h3yh3hgey5jhrtjrjerjnerj45ki45kjtk4e5ue5u5eu545u45j45j45uj45uj45u45u45u45u45jgjgjgfjrtjtjjtrjrtjrtjtrjrthhrew"),
+			},
+			wantDataLen: 0xFF,
+			wantRead:    2,
+			wantErr:     false,
+		},
+		{
 			name: "not_enough_data",
 			fields: fields{
 				Digits: 3,


### PR DESCRIPTION
Make parsing the length unsigned. 
For example when a variable length HEX field (with length prefix of 1 byte) has more then 0x7F data bytes it gives error:
```
DecodeLength() error = strconv.ParseInt: parsing "FF": value out of range
```
See new test case.