### PR TITLE
Explain that subfields can get reordered when packing

### DIFF
--- a/docs/composite-fields.md
+++ b/docs/composite-fields.md
@@ -150,6 +150,8 @@ With BER-TLV fields:
 
 > **Note:** To work with BerTLV subfields, we suggest using the `encoding.Binary` for the entire field and then use [moov-io/bertlv](https://github.com/moov-io/bertlv) to parse the subfields.
 
+> **Note on subfield order:** When unpacking and then packing non-positional fields, you can get a different output than the input due to the subfields being sorted when packing.
+
 
 ### 4. Nested Composite Fields with Data Set IDs
 


### PR DESCRIPTION
I've been surprised in the past when unpacking a message and then packing it just to find the end result is a different message. This is my attempt at documenting the reason why.