### PR TITLE
fix: unmarshaling to []byte for Binary and String fields

### DIFF
--- a/field/binary.go
+++ b/field/binary.go
@@ -110,6 +110,9 @@ func (f *Binary) Unmarshal(v interface{}) error {
 		case reflect.String:
 			val.SetString(hex.EncodeToString(f.value))
 		case reflect.Slice:
+			if val.Type().Elem().Kind() != reflect.Uint8 {
+				return fmt.Errorf("binary data can only be unmarshaled into []byte, got %s", val.Type())
+			}
 			val.SetBytes(f.value)
 		default:
 			return fmt.Errorf("unsupported reflect.Value type: %s", val.Kind())

--- a/field/composite.go
+++ b/field/composite.go
@@ -193,12 +193,18 @@ func (f *Composite) Unmarshal(v interface{}) error {
 
 		dataField := dataStruct.Field(i)
 		switch dataField.Kind() { //nolint:exhaustive
-		case reflect.Pointer, reflect.Interface, reflect.Slice:
-			if dataField.IsNil() && dataField.Kind() != reflect.Slice {
+		case reflect.Pointer, reflect.Interface:
+			if dataField.IsNil() {
 				dataField.Set(reflect.New(dataField.Type().Elem()))
 			}
 
 			err := messageField.Unmarshal(dataField.Interface())
+			if err != nil {
+				return fmt.Errorf("unmarshalling field %s: %w", indexTag.Tag, err)
+			}
+		case reflect.Slice:
+			// Pass reflect.Value for slices so they can be modified
+			err := messageField.Unmarshal(dataField)
 			if err != nil {
 				return fmt.Errorf("unmarshalling field %s: %w", indexTag.Tag, err)
 			}

--- a/field/string.go
+++ b/field/string.go
@@ -116,6 +116,11 @@ func (f *String) Unmarshal(v interface{}) error {
 			}
 
 			val.SetInt(int64(i))
+		case reflect.Slice:
+			if val.Type().Elem().Kind() != reflect.Uint8 {
+				return fmt.Errorf("can only be unmarshaled into []byte, got %s", val.Type())
+			}
+			val.SetBytes([]byte(f.value))
 		default:
 			return fmt.Errorf("unsupported reflect.Value type: %s", val.Kind())
 		}

--- a/message.go
+++ b/message.go
@@ -499,11 +499,17 @@ func (m *Message) Unmarshal(v interface{}) error {
 
 		dataField := dataStruct.Field(i)
 		switch dataField.Kind() { //nolint:exhaustive
-		case reflect.Pointer, reflect.Interface, reflect.Slice:
-			if dataField.IsNil() && dataField.Kind() != reflect.Slice {
+		case reflect.Pointer, reflect.Interface:
+			if dataField.IsNil() {
 				dataField.Set(reflect.New(dataField.Type().Elem()))
 			}
 			err := messageField.Unmarshal(dataField.Interface())
+			if err != nil {
+				return fmt.Errorf("failed to get value from field %d: %w", indexTag.ID, err)
+			}
+		case reflect.Slice:
+			// Pass reflect.Value for slices so they can be modified
+			err := messageField.Unmarshal(dataField)
 			if err != nil {
 				return fmt.Errorf("failed to get value from field %d: %w", indexTag.ID, err)
 			}


### PR DESCRIPTION
If you have data struct with []byte field and `field.Binary` in the spec, this PR fixes the issue with setting value to the field when `Unmarshal` is called.