### PR TITLE
fix: a binary field can marshal to a named string

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -2279,6 +2279,17 @@ func TestStructWithTypes(t *testing.T) {
 				},
 				expectedPackedString: "011040000000000000000000000000000000164242424242424242",
 			},
+			{
+				name: "struct with named string type and value set on a binary field",
+				input: struct {
+					MTI                  myString `index:"0"`
+					PrimaryAccountNumber myString `index:"4"`
+				}{
+					MTI:                  "0110",
+					PrimaryAccountNumber: myString("313233"), // "123" in Hex
+				},
+				expectedPackedString: "011010000000000000000000000000000000123",
+			},
 
 			// Tests for *string type
 			{

--- a/message_test.go
+++ b/message_test.go
@@ -2282,11 +2282,11 @@ func TestStructWithTypes(t *testing.T) {
 			{
 				name: "struct with named string type and value set on a binary field",
 				input: struct {
-					MTI                  myString `index:"0"`
-					PrimaryAccountNumber myString `index:"4"`
+					MTI        myString `index:"0"`
+					BinaryData myString `index:"4"`
 				}{
-					MTI:                  "0110",
-					PrimaryAccountNumber: myString("313233"), // "123" in Hex
+					MTI:        "0110",
+					BinaryData: myString("313233"), // "123" in Hex
 				},
 				expectedPackedString: "011010000000000000000000000000000000123",
 			},


### PR DESCRIPTION
Similar to https://github.com/moov-io/iso8583/pull/344 but this time for when the spec field is a Binary and has to Marshal into a named string.