### PR TITLE
feat(encoding): add nibble‑aware Track2BCD encoder/decoder for DE35

### DIFF
--- a/encoding/track2_bcd.go
+++ b/encoding/track2_bcd.go
@@ -1,0 +1,84 @@
+package encoding
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/yerden/go-util/bcd"
+
+	"github.com/moov-io/iso8583/utils"
+)
+
+// trackDigitsBCD defines the BCD mapping for digits '0'-'9' and the separator 'D'.
+var trackDigitsBCD = &bcd.BCD{
+	Map: func() map[byte]byte {
+		m := make(map[byte]byte, 11)
+		for c := byte('0'); c <= byte('9'); c++ {
+			m[c] = c - '0'
+		}
+		m['D'] = 0xD
+		return m
+	}(),
+	Filler:      0xF,
+	SwapNibbles: false,
+}
+
+var (
+	_         Encoder = (*track2BcdEncoder)(nil)
+	Track2BCD         = &track2BcdEncoder{}
+)
+
+type track2BcdEncoder struct{}
+
+// Encode converts a byte slice into BCD format.
+func (e track2BcdEncoder) Encode(src []byte) ([]byte, error) {
+	// if the number of digits is odd, add ‘0’ to the left
+	if len(src)%2 != 0 {
+		src = append([]byte("0"), src...)
+	}
+
+	enc := bcd.NewEncoder(trackDigitsBCD)
+	dst := make([]byte, bcd.EncodedLen(len(src)))
+	n, err := enc.Encode(dst, src)
+	if err != nil {
+		return nil, utils.NewSafeError(err, "failed to perform BCD encoding")
+	}
+	return dst[:n], nil
+}
+
+// Decode converts a BCD-encoded byte slice back to its original representation.
+func (e track2BcdEncoder) Decode(src []byte, length int) ([]byte, int, error) {
+	if length < 0 {
+		return nil, 0, fmt.Errorf("length should be positive, got %d", length)
+	}
+
+	// length is in nibbles; bytes to read = ceil(n/2)
+	decodedLen := length
+	if decodedLen%2 != 0 {
+		decodedLen++
+	}
+	read := bcd.EncodedLen(decodedLen) // = (decodedLen+1) / 2
+
+	if len(src) < read {
+		return nil, 0, fmt.Errorf("not enough data to decode. expected len %d, got %d", read, len(src))
+	}
+
+	dec := bcd.NewDecoder(trackDigitsBCD)
+	dst := make([]byte, decodedLen)
+	_, err := dec.Decode(dst, src[:read])
+	if err != nil {
+		return nil, 0, utils.NewSafeError(err, "failed to perform BCD decoding")
+	}
+
+	// remove the padding '0' if n is odd and truncate to 'length' nibbles.
+	out := dst[decodedLen-length:]
+
+	// reject hex nibbles outside the allowed set ('D').
+	invalidNibbleIndex := bytes.IndexFunc(out, func(r rune) bool {
+		return r >= 'A' && r <= 'F' && r != 'D'
+	})
+	if invalidNibbleIndex != -1 {
+		return nil, 0, fmt.Errorf("invalid track2 nibble decoded: %q", out[invalidNibbleIndex])
+	}
+	return out, read, nil
+}

--- a/encoding/track2_bcd_test.go
+++ b/encoding/track2_bcd_test.go
@@ -1,0 +1,106 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yerden/go-util/bcd"
+)
+
+func TestTrack2BCD(t *testing.T) {
+	t.Run("Decode - sample even length (36 digits -> 18 bytes)", func(t *testing.T) {
+		// "4000340000000504D2225111123400001230" (36 nibbles)
+		src := []byte{
+			0x40, 0x00, 0x34, 0x00, 0x00, 0x00, 0x05, 0x04,
+			0xD2, 0x22, 0x51, 0x11, 0x12, 0x34, 0x00, 0x00,
+			0x12, 0x30,
+		}
+		out, read, err := Track2BCD.Decode(src, 36)
+
+		require.NoError(t, err)
+		require.Equal(t, 18, read)
+		require.Equal(t, []byte("4000340000000504D2225111123400001230"), out)
+	})
+
+	t.Run("Decode - odd length with leading zero alignment", func(t *testing.T) {
+		// bytes 0x01,0x23 represent “0123” in BCD.
+		// length=3 => remove the extra leading nibble => “123”
+		out, read, err := Track2BCD.Decode([]byte{0x01, 0x23}, 3)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, read)
+		require.Equal(t, []byte("123"), out)
+	})
+
+	t.Run("Decode - accepts 'D' separator nibble (0xD)", func(t *testing.T) {
+		// 0x01,0x2D => "012D"; length=3 => "12D"
+		out, read, err := Track2BCD.Decode([]byte{0x01, 0x2D}, 3)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, read)
+		require.Equal(t, []byte("12D"), out)
+	})
+
+	t.Run("Decode - not enough data", func(t *testing.T) {
+		// length=4 => requires 2 bytes; only 1 byte provided
+		_, _, err := Track2BCD.Decode([]byte{0x12}, 4)
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to decode. expected len 2, got 1")
+	})
+
+	t.Run("Decode - invalid nibble (A..F except D)", func(t *testing.T) {
+		// 0x1A contains unmapped nibble 0xA => ErrBadBCD
+		_, _, err := Track2BCD.Decode([]byte{0x1A, 0x23}, 4)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD decoding")
+		require.ErrorIs(t, err, bcd.ErrBadBCD)
+	})
+
+	t.Run("Decode - ignores trailing bytes beyond ceil(n/2)", func(t *testing.T) {
+		// length=4 => reads 2 bytes; the third byte (0xFF) is ignored
+		out, read, err := Track2BCD.Decode([]byte{0x21, 0x43, 0xFF}, 4)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, read)
+		require.Equal(t, []byte("2143"), out)
+	})
+
+	t.Run("Encode - round-trip with sample", func(t *testing.T) {
+		in := []byte("4000340000000504D2225111123400001230") // 36 digits
+		packed, err := Track2BCD.Encode(in)
+		require.NoError(t, err)
+		require.Len(t, packed, 18) // ceil(36/2)
+
+		out, read, err := Track2BCD.Decode(packed, len(in))
+		require.NoError(t, err)
+		require.Equal(t, 18, read)
+		require.Equal(t, in, out)
+	})
+
+	t.Run("Encode - odd length uses leading zero (right-justified)", func(t *testing.T) {
+		packed, err := Track2BCD.Encode([]byte("123")) // 3 digits -> 0x01,0x23
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x01, 0x23}, packed)
+	})
+
+	t.Run("Encode - includes 'D' nibble", func(t *testing.T) {
+		packed, err := Track2BCD.Encode([]byte("12D3")) // -> 0x12,0xD3
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x12, 0xD3}, packed)
+	})
+
+	t.Run("Encode - invalid chars", func(t *testing.T) {
+		_, err := Track2BCD.Encode([]byte("abc")) // 'a', 'b', 'c' are not expected
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to perform BCD encoding")
+		require.ErrorIs(t, err, bcd.ErrBadInput)
+	})
+}
+
+func FuzzDecodeTrack2BCD(f *testing.F) {
+	enc := Track2BCD
+
+	f.Fuzz(func(t *testing.T, data []byte, length int) {
+		enc.Decode(data, length)
+	})
+}

--- a/specs/builder.go
+++ b/specs/builder.go
@@ -70,6 +70,7 @@ var (
 		"ASCIIToHex": encoding.ASCIIHexToBytes,
 		"LBCD":       encoding.LBCD,
 		"BerTLVTag":  encoding.BerTLVTag,
+		"Track2BCD":  encoding.Track2BCD,
 	}
 
 	EncodingsIntToExt = map[string]string{
@@ -80,6 +81,7 @@ var (
 		"hexToASCIIEncoder": "HexToASCII",
 		"asciiToHexEncoder": "ASCIIToHex",
 		"lBCDEncoder":       "LBCD",
+		"track2BcdEncoder":  "Track2BCD",
 	}
 
 	PaddersIntToExt = map[string]string{


### PR DESCRIPTION
### Summary

- Introduces encoding.Track2BCD, a nibble‑aware encoder/decoder for packed BCD Track‑2 data.
- Interprets length as number of digits (nibbles) and consumes exactly ceil(n/2) bytes.
- Handles odd lengths with the leading‑zero rule.
- Validates the Track‑2 nibble set (0–9 and separator nibble 0xD).
- Compatible with prefix.Binary.L using a light Track‑2 packer/unpacker (optional).

> This is additive and opt‑in; existing encoders/prefixers continue to work as before.

### Motivation & context

Per Visa’s F35 spec, the length byte is the count of hex digits (nibbles), not bytes; content is 4‑bit BCD (unsigned packed), and odd digit counts use a leading zero in the first unused half‑byte. Track‑2 also includes a separator nibble 0xD.
Generic ASCII/hex decoders don’t match these semantics (they either over‑read bytes or fail on non‑ASCII 0xD), so parsing desynchronizes.

### What’s included

- `encoding.Track2BCD` (encoder/decoder).
- Unit tests: even/odd lengths, separator, invalid nibbles, round‑trip.

### Backward compatibility

- No breaking changes.
- New type is opt‑in. Existing field specs and encoders remain untouched.