### PR TITLE
Fix getters

### DIFF
--- a/message.go
+++ b/message.go
@@ -138,7 +138,7 @@ func (m *Message) GetMTI() (string, error) {
 }
 
 // GetString returns the string representation of the field with the given ID.
-// If the field does not exist in the message, an empty value be returned. If
+// If the field does not exist in the message, an empty value will be returned. If
 // the field ID is not defined in the specification, an error will be returned.
 func (m *Message) GetString(id int) (string, error) {
 	m.mu.Lock()
@@ -162,7 +162,7 @@ func (m *Message) GetString(id int) (string, error) {
 }
 
 // GetBytes returns the byte slice representation of the field with the given ID.
-// If the field does not exist in the message, nil be returned. If the field ID
+// If the field does not exist in the message, nil will be returned. If the field ID
 // is not defined in the specification, an error will be returned.
 func (m *Message) GetBytes(id int) ([]byte, error) {
 	m.mu.Lock()


### PR DESCRIPTION
# ⚠️ Breaking Changes

**GetField() now returns nil for unset fields**: `GetField(id)` returns `nil` if the field is not set or not defined in the specification, whereas previously it always returned a field instance.

Migration:
- Add nil checks before using the returned field
- Or migrate to `GetString(id)` / `GetBytes(id)` which handle nil safely and return zero values for unset fields

This change aligns with the new lazy field loading behavior and makes field presence checking explicit.

P.S. This fixes the issue introduced in v0.24.0 where getting the value of a field that wasn't set was setting it.