### PR TITLE
return typed nil so you can use nil safe methods of the fields

### DIFF
--- a/message.go
+++ b/message.go
@@ -199,11 +199,17 @@ func (m *Message) GetField(id int) field.Field {
 func (m *Message) getField(id int) (field.Field, error) {
 	f := m.fields[id]
 	if f == nil {
-		if _, ok := m.spec.Fields[id]; !ok {
+		specField, ok := m.spec.Fields[id]
+		if !ok {
 			return nil, fmt.Errorf("field %d is not defined in the spec", id)
 		}
 
-		return nil, nil
+		t := reflect.TypeOf(specField)
+		if t == nil {
+			return nil, fmt.Errorf("field %d has nil type in the spec", id)
+		}
+
+		return reflect.Zero(t).Interface().(field.Field), nil
 	}
 
 	return f, nil

--- a/message_test.go
+++ b/message_test.go
@@ -1237,6 +1237,40 @@ func TestPackUnpack(t *testing.T) {
 	})
 }
 
+func TestMessageGetField(t *testing.T) {
+	spec := &MessageSpec{
+		Fields: map[int]field.Field{
+			0: field.NewString(&field.Spec{
+				Length:      4,
+				Description: "Message Type Indicator",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			1: field.NewBitmap(&field.Spec{
+				Description: "Bitmap",
+				Enc:         encoding.BytesToASCIIHex,
+				Pref:        prefix.Hex.Fixed,
+			}),
+			2: field.NewString(&field.Spec{
+				Length:      19,
+				Description: "Primary Account Number",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+		},
+	}
+
+	t.Run("When field is not set, GetField returns typed nil", func(t *testing.T) {
+		message := NewMessage(spec)
+		pan := message.GetField(2)
+		require.Nil(t, pan)
+
+		s, err := pan.String()
+		require.NoError(t, err)
+		require.Empty(t, s)
+	})
+}
+
 func TestMessageJSON(t *testing.T) {
 	spec := &MessageSpec{
 		Fields: map[int]field.Field{


### PR DESCRIPTION
## Background

Before v0.24.0, `GetField` always returned a field instance, even if the field hadn’t been set on the message. Since v0.24.0 (see: https://github.com/moov-io/iso8583/releases/tag/v0.24.0
), callers need to handle a nil return value from `GetField`.

## What this PR changes

With this PR, methods on an unset (nil) field can be called safely and return sensible defaults instead of panicking.

Example:

```
f := msg.GetField(2)
if f == nil {
    fmt.Println("f is nil")
}

str, err := f.String()
// err => nil
// str => ""
```

This helps in scenarios where you receive a message and need to read a field that may or may not be present, without forcing nil checks before every method call.

While this change may prevent some old integrations from panicking, it looks dangerous as not all field types are nil-safe. So, calling `String`, `Bytes`, `Value` is safe for most of the fields, but not for `Composite`. Other methods are not `nil-safe`. 

As a migration path it's recomended to use `msg.GetString(n)`, `msg.GetBytes(n)` which will not panic if field is not set.

Discussion in open, but I'm leaning towards not making this change.