### PR TITLE
feat: add support for re-marshaling unknown TLV tags in MarshalPath

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -806,6 +806,15 @@ func (m *Composite) MarshalPath(path string, value any) error {
 
 	field, err := m.getOrCreateField(id)
 	if err != nil {
+		// at the moment getOrCreateField only returns an error if the field is not in spec
+		// if the passed value is of type Field, and there is no subPath, we can set it directly without returning an error
+		// this allows us to restore subfields corresponding to unknown TLV tags
+		if v, ok := value.(Field); !hasSubPath && m.skipUnknownTLVTags() &&
+			m.spec.Tag.StoreUnknownTLVTags && ok {
+			m.subfields[id] = v
+
+			return nil
+		}
 		return fmt.Errorf("getting or creating subfield %s: %w", id, err)
 	}
 

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -471,7 +471,7 @@ func TestCompositeField_MarshalPath(t *testing.T) {
 		require.Contains(t, err.Error(), "field FF is not defined in the spec")
 	})
 
-	t.Run("allows persisting a field no tin spec if the composite field is configured for unknown TLV support", func(t *testing.T) {
+	t.Run("allows persisting a field not in spec if the composite field is configured for unknown TLV support", func(t *testing.T) {
 		composite := NewComposite(compositeTestSpecWithTagPaddingAndUnknownTLVSupport)
 		err := composite.MarshalPath("11.FF",
 			&Binary{value: []byte{7, 4, 3}})

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -98,6 +98,60 @@ var (
 		},
 	}
 
+	compositeTestSpecWithTagPaddingAndUnknownTLVSupport = &Spec{
+		Length:      30,
+		Description: "Test Spec",
+		Pref:        prefix.ASCII.LL,
+		Tag: &TagSpec{
+			Length: 2,
+			Enc:    encoding.ASCII,
+			Pad:    padding.Left('0'),
+			Sort:   sort.StringsByInt,
+		},
+		Subfields: map[string]Field{
+			"1": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"2": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"3": NewNumeric(&Spec{
+				Length:      2,
+				Description: "Numeric Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"11": NewComposite(&Spec{
+				Length:      6,
+				Description: "Sub-Composite Field",
+				Pref:        prefix.ASCII.LL,
+				Tag: &TagSpec{
+					Length:              2,
+					Enc:                 encoding.ASCII,
+					Pad:                 padding.Left('0'),
+					Sort:                sort.StringsByInt,
+					SkipUnknownTLVTags:  true,
+					StoreUnknownTLVTags: true,
+					PrefUnknownTLV:      prefix.ASCII.LL,
+				},
+				Subfields: map[string]Field{
+					"1": NewString(&Spec{
+						Length:      2,
+						Description: "String Field",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.LL,
+					}),
+				},
+			}),
+		},
+	}
+
 	compositeTestSpecWithDefaultBitmap = &Spec{
 		Length:      36,
 		Description: "Test Spec",
@@ -415,6 +469,23 @@ func TestCompositeField_MarshalPath(t *testing.T) {
 		composite := NewComposite(compositeTestSpecWithTagPadding)
 		err := composite.MarshalPath("11.FF", 743)
 		require.Contains(t, err.Error(), "field FF is not defined in the spec")
+	})
+
+	t.Run("allows persisting a field no tin spec if the composite field is configured for unknown TLV support", func(t *testing.T) {
+		composite := NewComposite(compositeTestSpecWithTagPaddingAndUnknownTLVSupport)
+		err := composite.MarshalPath("11.FF",
+			&Binary{value: []byte{7, 4, 3}})
+		require.NoError(t, err)
+
+		// check that the value was set correctly
+		subfield, ok := composite.subfields["11"]
+		require.True(t, ok)
+
+		unknownTLV, ok := subfield.(*Composite).subfields["FF"]
+		require.True(t, ok)
+
+		val, err := unknownTLV.Bytes()
+		require.Equal(t, []byte{7, 4, 3}, val)
 	})
 
 	t.Run("non-composite nested error", func(t *testing.T) {

--- a/unknown_tags.go
+++ b/unknown_tags.go
@@ -16,6 +16,20 @@ func UnknownTags(message *Message) map[string]field.Field {
 	return result
 }
 
+// UnknownCompositeTags returns unknown TLV tags found in the composite field after unpacking,
+// keyed by their dot separated paths (e.g., "9F36" for unknown tag 9F36 inside the composite).
+// This requires StoreUnknownTLVTags to be enabled in the composite field specs that may contain
+// unknown tags.
+func UnknownCompositeTags(composite *field.Composite) map[string]field.Field {
+	if composite == nil {
+		return make(map[string]field.Field)
+	}
+
+	result := make(map[string]field.Field)
+	collectUnknownTags(composite, composite.Spec().Subfields, "", result)
+	return result
+}
+
 // collectUnknownTags recursively walks a field container, comparing
 // subfield keys against the spec's subfield definitions. Any key present
 // in GetSubfields() but missing from specSubfields is an unknown tag.

--- a/unknown_tags_test.go
+++ b/unknown_tags_test.go
@@ -81,8 +81,8 @@ func TestUnknownTags(t *testing.T) {
 		data = append(data, 0x9a, 0x03, 0x21, 0x07, 0x20)                         // 9A
 		data = append(data, 0x9f, 0x02, 0x06, 0x00, 0x00, 0x00, 0x00, 0x05, 0x01) // 9F02
 		// Unknown tags
-		data = append(data, 0x9f, 0x36, 0x02, 0x01, 0x57)                   // 9F36
-		data = append(data, 0x9f, 0x37, 0x04, 0x9b, 0xad, 0xbc, 0xab)       // 9F37
+		data = append(data, 0x9f, 0x36, 0x02, 0x01, 0x57)             // 9F36
+		data = append(data, 0x9f, 0x37, 0x04, 0x9b, 0xad, 0xbc, 0xab) // 9F37
 
 		err := msg.Unpack(data)
 		require.NoError(t, err)
@@ -171,6 +171,139 @@ func TestUnknownTags(t *testing.T) {
 
 		// Unknown tags are not stored, so UnknownTags returns empty
 		unknownTags := UnknownTags(msg)
+		require.Empty(t, unknownTags)
+	})
+}
+
+func TestUnknownCompositeTags(t *testing.T) {
+	spec := &field.Spec{
+		Length:      999,
+		Description: "Processing Code",
+		Pref:        prefix.ASCII.LLL,
+		Tag: &field.TagSpec{
+			Sort: sort.StringsByInt,
+		},
+		Subfields: map[string]field.Field{
+			"1": field.NewString(&field.Spec{
+				Length:      2,
+				Description: "Transaction Type",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			"2": field.NewComposite(&field.Spec{
+				Length:      100,
+				Description: "Nested TLV",
+				Pref:        prefix.ASCII.LLL,
+				Tag: &field.TagSpec{
+					Enc:                 encoding.BerTLVTag,
+					Sort:                sort.StringsByHex,
+					SkipUnknownTLVTags:  true,
+					StoreUnknownTLVTags: true,
+				},
+				Subfields: map[string]field.Field{
+					"9A": field.NewHex(&field.Spec{
+						Description: "Transaction Date",
+						Enc:         encoding.Binary,
+						Pref:        prefix.BerTLV,
+					}),
+					"9F02": field.NewHex(&field.Spec{
+						Description: "Amount, Authorized (Numeric)",
+						Enc:         encoding.Binary,
+						Pref:        prefix.BerTLV,
+					}),
+				},
+			}),
+		},
+	}
+
+	t.Run("returns unknown tags from nested composites", func(t *testing.T) {
+		// Build data with known + unknown TLV tags inside field 2
+		data := make([]byte, 0, 34)
+		// LLL = 31
+		data = append(data, []byte("031")...)
+		// Subfield 1 value
+		data = append(data, []byte("00")...)
+		// LLL for TLV field 2
+		data = append(data, []byte("026")...)
+		// Known tags
+		data = append(data, 0x9a, 0x03, 0x21, 0x07, 0x20)                         // 9A
+		data = append(data, 0x9f, 0x02, 0x06, 0x00, 0x00, 0x00, 0x00, 0x05, 0x01) // 9F02
+		// Unknown tags
+		data = append(data, 0x9f, 0x36, 0x02, 0x01, 0x57)             // 9F36
+		data = append(data, 0x9f, 0x37, 0x04, 0x9b, 0xad, 0xbc, 0xab) // 9F37
+
+		f := field.NewComposite(spec)
+		_, err := f.Unpack(data)
+		require.NoError(t, err)
+
+		unknownTags := UnknownCompositeTags(f)
+		require.Len(t, unknownTags, 2)
+		require.Contains(t, unknownTags, "2.9F36")
+		require.Contains(t, unknownTags, "2.9F37")
+
+		// verify we can inspect the field data
+		f9F36Bytes, err := unknownTags["2.9F36"].Bytes()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x01, 0x57}, f9F36Bytes)
+	})
+
+	t.Run("returns empty map when no unknown tags", func(t *testing.T) {
+		// Build data with only known tags
+		data := make([]byte, 0, 22)
+		// LLL = 19
+		data = append(data, []byte("019")...)
+		// Subfield 1 value
+		data = append(data, []byte("00")...)
+		// LLL for TLV field 2
+		data = append(data, []byte("014")...)
+		// Only known tags
+		data = append(data, 0x9a, 0x03, 0x21, 0x07, 0x20)                         // 9A
+		data = append(data, 0x9f, 0x02, 0x06, 0x00, 0x00, 0x00, 0x00, 0x05, 0x01) // 9F02
+
+		f := field.NewComposite(spec)
+		_, err := f.Unpack(data)
+		require.NoError(t, err)
+
+		unknownTags := UnknownCompositeTags(f)
+		require.Empty(t, unknownTags)
+	})
+
+	t.Run("returns empty when StoreUnknownTLVTags is disabled", func(t *testing.T) {
+		noStoreSpec := &field.Spec{
+			Length:      999,
+			Description: "Processing Code",
+			Pref:        prefix.ASCII.LLL,
+			Tag: &field.TagSpec{
+				Enc:                 encoding.BerTLVTag,
+				Sort:                sort.StringsByHex,
+				SkipUnknownTLVTags:  true,
+				StoreUnknownTLVTags: false,
+			},
+			Subfields: map[string]field.Field{
+				"9A": field.NewHex(&field.Spec{
+					Description: "Transaction Date",
+					Enc:         encoding.Binary,
+					Pref:        prefix.BerTLV,
+				}),
+			},
+		}
+
+		// Build data with unknown tags
+		data := make([]byte, 0, 20)
+		// LLL = 17
+		data = append(data, []byte("017")...)
+		// Known tag
+		data = append(data, 0x9a, 0x03, 0x21, 0x07, 0x20) // 9A
+		// Unknown tags - skipped but not stored
+		data = append(data, 0x9f, 0x36, 0x02, 0x01, 0x57)             // 9F36
+		data = append(data, 0x9f, 0x37, 0x04, 0x9b, 0xad, 0xbc, 0xab) // 9F37
+
+		f := field.NewComposite(noStoreSpec)
+		_, err := f.Unpack(data)
+		require.NoError(t, err)
+
+		// Unknown tags are not stored, so UnknownTags returns empty
+		unknownTags := UnknownCompositeTags(f)
 		require.Empty(t, unknownTags)
 	})
 }

--- a/unknown_tags_test.go
+++ b/unknown_tags_test.go
@@ -66,6 +66,12 @@ func TestUnknownTags(t *testing.T) {
 		},
 	}
 
+	t.Run("returns empty map for nil message", func(t *testing.T) {
+		unknownTags := UnknownTags(nil)
+		require.NotNil(t, unknownTags)
+		require.Empty(t, unknownTags)
+	})
+
 	t.Run("returns unknown tags from nested composites", func(t *testing.T) {
 		msg := NewMessage(spec)
 
@@ -215,6 +221,12 @@ func TestUnknownCompositeTags(t *testing.T) {
 			}),
 		},
 	}
+
+	t.Run("returns empty map for nil composite", func(t *testing.T) {
+		unknownTags := UnknownCompositeTags(nil)
+		require.NotNil(t, unknownTags)
+		require.Empty(t, unknownTags)
+	})
 
 	t.Run("returns unknown tags from nested composites", func(t *testing.T) {
 		// Build data with known + unknown TLV tags inside field 2


### PR DESCRIPTION
Currently, we have the option to parse and unknown TLV tags from a message.
However, once the message is un-marshaled into a struct, there is no way to re-add those fields back when re-marshaling from the struct.

The only current approach I could find would require keeping a reference to the entire message, and re-marshaling the (eventually modified) struct into the original message.

What I'm proposing here is an extension of the `MarshalPath` method for composite fields: if a composite field allows parsing and storing unknown TLV tags, then its `MarshalPath` implementation will allow directly setting a value provided it satisfies the `Field` interface if no definition is found in the spec.

Additionally, I've added an utility method to retrieve unknown TLVs: for our usage of the library, we sometimes delay parsing some data elements until necessary.
This means that we sometimes don't parse the entire message, but just a `Composite` spec for the specific data elements.