### PR TITLE
feat: add MessageScanner for partial message parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ ISO8583 implements an ISO 8583 message reader and writer in Go. ISO 8583 is an i
     - [Working with ISO 8583 Messages](#working-with-iso-8583-messages)
     - [Setting Message Data](#setting-message-data)
     - [Getting Message Data](#getting-message-data)
+    - [Partial Message Parsing (MessageScanner)](#partial-message-parsing-messagescanner)
 	- [Inspecting message fields](#inspecting-message-fields)
 	- [JSON Encoding and Decoding](#json-encoding-and-decoding)
 	- [Working with Unknown TLV Tags](#working-with-unknown-tlv-tags)
@@ -477,6 +478,52 @@ fmt.Println(auth.MTI.Value())
 fmt.Println(auth.Amount.Value())
 ```
 </details>
+
+### Partial Message Parsing (MessageScanner)
+
+When you only need to inspect a few fields from a raw message — for example, reading the MTI to decide how to route, or extracting the STAN for logging — you can use `MessageScanner` instead of unpacking the entire message.
+
+`MessageScanner` is a forward-only cursor that parses fields on demand. It consumes bytes sequentially but only returns the fields you ask for, making it lightweight and suitable for proxies and routers.
+
+```go
+s := iso8583.NewMessageScanner(spec, rawBytes)
+
+// Scan MTI to decide how to handle the message
+f, err := s.ScanField(0)
+if err != nil {
+    // handle error
+}
+
+mti, err := f.String()
+if err != nil {
+    // handle error
+}
+
+if mti == "0800" {
+    // Network management message — forward raw bytes to a
+    // dedicated handler without further parsing
+    handleNetworkMessage(rawBytes)
+    return
+}
+
+// For other messages, continue scanning to get STAN
+f, err = s.ScanField(11)
+if err != nil {
+    // handle error
+}
+
+stan, err := f.String()
+if err != nil {
+    // handle error
+}
+
+// Route or log based on MTI and STAN
+fmt.Printf("MTI: %s, STAN: %s\n", mti, stan)
+```
+
+Key behaviors:
+- **Forward-only**: fields must be scanned in ascending order. Scanning a field at or before the current position returns an error.
+- **Minimal allocations**: fields between the current position and the target are consumed from the byte stream but discarded. Only the requested field is allocated and returned.
 
 ### Inspecting Message Fields
 

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,171 @@
+package iso8583
+
+import (
+	"fmt"
+	"strconv"
+
+	iso8583errors "github.com/moov-io/iso8583/errors"
+	"github.com/moov-io/iso8583/field"
+)
+
+// MessageScanner provides forward-only cursor-based parsing of an ISO 8583
+// message. It is designed for cases where only a few fields need to be
+// inspected (e.g., MTI and STAN in a proxy) without unpacking the entire
+// message.
+//
+// MTI and bitmap are parsed automatically as needed. Fields can only be
+// scanned in ascending order; attempting to scan a field at or before the
+// current cursor position returns an error.
+type MessageScanner struct {
+	spec   *MessageSpec
+	src    []byte
+	offset int
+
+	bitmap        *field.Bitmap
+	lastID        int // last scanned field ID, -1 initially
+	scannedBitmap bool
+}
+
+// NewMessageScanner creates a new scanner for the given spec and raw message
+// bytes. It does not perform any parsing until ScanField is called.
+func NewMessageScanner(spec *MessageSpec, src []byte) *MessageScanner {
+	return &MessageScanner{
+		spec:   spec,
+		src:    src,
+		lastID: -1,
+	}
+}
+
+// ScanField parses the message up to and including the field with the given
+// id, returning the parsed field. Fields between the current cursor position
+// and the target field are consumed but discarded.
+//
+// Field 0 (MTI) must be scanned before any other field. Fields must be
+// scanned in strictly ascending order. Any error is returned as
+// *iso8583errors.UnpackError.
+func (s *MessageScanner) ScanField(id int) (field.Field, error) {
+	f, err := s.scanField(id)
+	if err != nil {
+		return nil, &iso8583errors.UnpackError{
+			Err:        err,
+			FieldID:    strconv.Itoa(id),
+			RawMessage: s.src,
+		}
+	}
+	return f, nil
+}
+
+func (s *MessageScanner) scanField(id int) (field.Field, error) {
+	if id < 0 {
+		return nil, fmt.Errorf("invalid field id: %d", id)
+	}
+
+	if id <= s.lastID {
+		return nil, fmt.Errorf("field %d is at or before current position %d: scanner is forward-only", id, s.lastID)
+	}
+
+	// Ensure MTI is scanned; return it if that's what was requested.
+	if s.lastID == -1 {
+		f, err := s.scanMTI()
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan MTI: %w", err)
+		}
+		if id == mtiIdx {
+			return f, nil
+		}
+	}
+
+	// Ensure bitmap is scanned; return it if that's what was requested.
+	if !s.scannedBitmap {
+		if err := s.parseBitmap(); err != nil {
+			return nil, fmt.Errorf("failed to parse bitmap: %w", err)
+		}
+		if id == bitmapIdx {
+			return s.bitmap, nil
+		}
+	}
+
+	for i := s.nextDataField(); i <= id && i <= s.bitmap.Len(); i = s.nextDataField() {
+		if s.bitmap.IsBitmapPresenceBit(i) {
+			s.lastID = i
+			continue
+		}
+
+		if !s.bitmap.IsSet(i) {
+			s.lastID = i
+			continue
+		}
+
+		specField, ok := s.spec.Fields[i]
+		if !ok {
+			return nil, fmt.Errorf("field %d is not defined in the spec", i)
+		}
+
+		f := field.NewInstanceOf(specField)
+
+		read, err := f.Unpack(s.src[s.offset:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack field %d (%s): %w", i, f.Spec().Description, err)
+		}
+
+		s.offset += read
+		s.lastID = i
+
+		if i == id {
+			return f, nil
+		}
+	}
+
+	// Field was not present in the bitmap
+	return nil, fmt.Errorf("field %d is not set in the bitmap", id)
+}
+
+func (s *MessageScanner) scanMTI() (field.Field, error) {
+	specField, ok := s.spec.Fields[mtiIdx]
+	if !ok {
+		return nil, fmt.Errorf("field %d (MTI) is not defined in the spec", mtiIdx)
+	}
+
+	f := field.NewInstanceOf(specField)
+
+	read, err := f.Unpack(s.src[s.offset:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack MTI: %w", err)
+	}
+
+	s.offset += read
+	s.lastID = mtiIdx
+
+	return f, nil
+}
+
+func (s *MessageScanner) parseBitmap() error {
+	specField, ok := s.spec.Fields[bitmapIdx]
+	if !ok {
+		return fmt.Errorf("field %d (bitmap) is not defined in the spec", bitmapIdx)
+	}
+
+	bmp, ok := field.NewInstanceOf(specField).(*field.Bitmap)
+	if !ok {
+		return fmt.Errorf("field %d is not a bitmap", bitmapIdx)
+	}
+
+	bmp.Reset()
+
+	read, err := bmp.Unpack(s.src[s.offset:])
+	if err != nil {
+		return fmt.Errorf("failed to unpack bitmap: %w", err)
+	}
+
+	s.offset += read
+	s.bitmap = bmp
+	s.scannedBitmap = true
+	s.lastID = bitmapIdx
+
+	return nil
+}
+
+// nextDataField returns the next field ID to process after lastID.
+func (s *MessageScanner) nextDataField() int {
+	return max(s.lastID+1, 2)
+}

--- a/scanner.go
+++ b/scanner.go
@@ -38,50 +38,50 @@ func NewMessageScanner(spec *MessageSpec, src []byte) *MessageScanner {
 
 // ScanField parses the message up to and including the field with the given
 // id, returning the parsed field. Fields between the current cursor position
-// and the target field are consumed but discarded.
+// and the target field are consumed but discarded. MTI and bitmap are parsed
+// automatically when needed.
 //
-// Field 0 (MTI) must be scanned before any other field. Fields must be
-// scanned in strictly ascending order. Any error is returned as
-// *iso8583errors.UnpackError.
+// Fields must be scanned in strictly ascending order. Any error is returned
+// as *iso8583errors.UnpackError.
 func (s *MessageScanner) ScanField(id int) (field.Field, error) {
-	f, err := s.scanField(id)
+	f, fieldID, err := s.scanField(id)
 	if err != nil {
 		return nil, &iso8583errors.UnpackError{
 			Err:        err,
-			FieldID:    strconv.Itoa(id),
+			FieldID:    fieldID,
 			RawMessage: s.src,
 		}
 	}
 	return f, nil
 }
 
-func (s *MessageScanner) scanField(id int) (field.Field, error) {
+func (s *MessageScanner) scanField(id int) (field.Field, string, error) {
 	if id < 0 {
-		return nil, fmt.Errorf("invalid field id: %d", id)
+		return nil, strconv.Itoa(id), fmt.Errorf("invalid field id: %d", id)
 	}
 
 	if id <= s.lastID {
-		return nil, fmt.Errorf("field %d is at or before current position %d: scanner is forward-only", id, s.lastID)
+		return nil, strconv.Itoa(id), fmt.Errorf("field %d is at or before current position %d: scanner is forward-only", id, s.lastID)
 	}
 
 	// Ensure MTI is scanned; return it if that's what was requested.
 	if s.lastID == -1 {
 		f, err := s.scanMTI()
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan MTI: %w", err)
+			return nil, strconv.Itoa(mtiIdx), err
 		}
 		if id == mtiIdx {
-			return f, nil
+			return f, "", nil
 		}
 	}
 
 	// Ensure bitmap is scanned; return it if that's what was requested.
 	if !s.scannedBitmap {
 		if err := s.parseBitmap(); err != nil {
-			return nil, fmt.Errorf("failed to parse bitmap: %w", err)
+			return nil, strconv.Itoa(bitmapIdx), err
 		}
 		if id == bitmapIdx {
-			return s.bitmap, nil
+			return s.bitmap, "", nil
 		}
 	}
 
@@ -98,26 +98,25 @@ func (s *MessageScanner) scanField(id int) (field.Field, error) {
 
 		specField, ok := s.spec.Fields[i]
 		if !ok {
-			return nil, fmt.Errorf("field %d is not defined in the spec", i)
+			return nil, strconv.Itoa(i), fmt.Errorf("field %d is not defined in the spec", i)
 		}
 
 		f := field.NewInstanceOf(specField)
 
 		read, err := f.Unpack(s.src[s.offset:])
 		if err != nil {
-			return nil, fmt.Errorf("failed to unpack field %d (%s): %w", i, f.Spec().Description, err)
+			return nil, strconv.Itoa(i), fmt.Errorf("failed to unpack field %d (%s): %w", i, f.Spec().Description, err)
 		}
 
 		s.offset += read
 		s.lastID = i
 
 		if i == id {
-			return f, nil
+			return f, "", nil
 		}
 	}
 
-	// Field was not present in the bitmap
-	return nil, fmt.Errorf("field %d is not set in the bitmap", id)
+	return nil, strconv.Itoa(id), fmt.Errorf("field %d is not set in the bitmap", id)
 }
 
 func (s *MessageScanner) scanMTI() (field.Field, error) {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,239 @@
+package iso8583
+
+import (
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	iso8583errors "github.com/moov-io/iso8583/errors"
+	"github.com/moov-io/iso8583/field"
+	"github.com/moov-io/iso8583/padding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageScanner(t *testing.T) {
+	spec := &MessageSpec{
+		Fields: map[int]field.Field{
+			0: field.NewString(&field.Spec{
+				Length:      4,
+				Description: "Message Type Indicator",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			1: field.NewBitmap(&field.Spec{
+				Description: "Bitmap",
+				Enc:         encoding.BytesToASCIIHex,
+				Pref:        prefix.Hex.Fixed,
+			}),
+			2: field.NewString(&field.Spec{
+				Length:      19,
+				Description: "Primary Account Number",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			3: field.NewComposite(&field.Spec{
+				Length:      6,
+				Description: "Processing Code",
+				Pref:        prefix.ASCII.Fixed,
+				Tag: &field.TagSpec{
+					Sort: sort.StringsByInt,
+				},
+				Subfields: map[string]field.Field{
+					"1": field.NewString(&field.Spec{
+						Length:      2,
+						Description: "Transaction Type",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					"2": field.NewString(&field.Spec{
+						Length:      2,
+						Description: "From Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					"3": field.NewString(&field.Spec{
+						Length:      2,
+						Description: "To Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+				},
+			}),
+			4: field.NewString(&field.Spec{
+				Length:      12,
+				Description: "Transaction Amount",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+				Pad:         padding.Left('0'),
+			}),
+			11: field.NewString(&field.Spec{
+				Length:      6,
+				Description: "STAN",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+				Pad:         padding.Left('0'),
+			}),
+		},
+	}
+
+	// Pack a full message for use in tests
+	packMessage := func(t *testing.T) []byte {
+		t.Helper()
+		msg := NewMessage(spec)
+		msg.MTI("0200")
+		require.NoError(t, msg.Field(2, "4242424242424242"))
+		require.NoError(t, msg.Field(3, "123456"))
+		require.NoError(t, msg.Field(4, "100"))
+		require.NoError(t, msg.Field(11, "123"))
+
+		packed, err := msg.Pack()
+		require.NoError(t, err)
+		return packed
+	}
+
+	t.Run("scan MTI only", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		f, err := s.ScanField(0)
+		require.NoError(t, err)
+
+		mti, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "0200", mti)
+	})
+
+	t.Run("scan MTI then STAN", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		f, err := s.ScanField(0)
+		require.NoError(t, err)
+		mti, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "0200", mti)
+
+		f, err = s.ScanField(11)
+		require.NoError(t, err)
+		stan, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "123", stan)
+	})
+
+	t.Run("scan multiple fields in order", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		f, err := s.ScanField(0)
+		require.NoError(t, err)
+		mti, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "0200", mti)
+
+		f, err = s.ScanField(2)
+		require.NoError(t, err)
+		pan, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "4242424242424242", pan)
+
+		f, err = s.ScanField(4)
+		require.NoError(t, err)
+		amount, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "100", amount)
+	})
+
+	t.Run("scan only STAN", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		f, err := s.ScanField(11)
+		require.NoError(t, err)
+
+		stan, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "123", stan)
+	})
+
+	t.Run("error when scanning backwards", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		_, err := s.ScanField(0)
+		require.NoError(t, err)
+
+		_, err = s.ScanField(4)
+		require.NoError(t, err)
+
+		_, err = s.ScanField(2)
+		require.Error(t, err)
+
+		var unpackErr *iso8583errors.UnpackError
+		require.ErrorAs(t, err, &unpackErr)
+		assert.Contains(t, unpackErr.Err.Error(), "forward-only")
+	})
+
+	t.Run("error when scanning same field twice", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		_, err := s.ScanField(0)
+		require.NoError(t, err)
+
+		_, err = s.ScanField(0)
+		require.Error(t, err)
+	})
+
+	t.Run("error when field not in bitmap", func(t *testing.T) {
+		// Pack message with only fields 2 and 3
+		msg := NewMessage(spec)
+		msg.MTI("0200")
+		require.NoError(t, msg.Field(2, "4242424242424242"))
+		require.NoError(t, msg.Field(3, "123456"))
+		packed, err := msg.Pack()
+		require.NoError(t, err)
+
+		s := NewMessageScanner(spec, packed)
+
+		_, err = s.ScanField(0)
+		require.NoError(t, err)
+
+		// Field 11 is not set in the bitmap
+		_, err = s.ScanField(11)
+		require.Error(t, err)
+
+		var unpackErr *iso8583errors.UnpackError
+		require.ErrorAs(t, err, &unpackErr)
+		assert.Contains(t, unpackErr.Err.Error(), "not set in the bitmap")
+	})
+
+	t.Run("proxy use case: branch on MTI", func(t *testing.T) {
+		packed := packMessage(t)
+
+		s := NewMessageScanner(spec, packed)
+
+		f, err := s.ScanField(0)
+		require.NoError(t, err)
+
+		mti, err := f.String()
+		require.NoError(t, err)
+
+		// Not a network message, so continue to get STAN
+		assert.Equal(t, "0200", mti)
+
+		f, err = s.ScanField(11)
+		require.NoError(t, err)
+
+		stan, err := f.String()
+		require.NoError(t, err)
+		assert.Equal(t, "123", stan)
+	})
+}


### PR DESCRIPTION
## Summary

- Add `MessageScanner`, a forward-only cursor for parsing individual ISO 8583 fields on demand without unpacking the entire message
- Designed for proxy/router use cases where only a few fields (e.g., MTI, STAN) need to be inspected before routing raw bytes
- Add README section with usage example

Here is how scanner can be used:

```go
s := iso8583.NewMessageScanner(spec, rawBytes)

// Scan MTI to decide how to handle the message
f, err := s.ScanField(0)
if err != nil {
    // handle error
}

mti, err := f.String()
if err != nil {
    // handle error
}

if mti == "0800" {
    // Network management message — forward raw bytes to a
    // dedicated handler without further parsing
    handleNetworkMessage(rawBytes)
    return
}

// For other messages, continue scanning to get STAN
f, err = s.ScanField(11)
if err != nil {
    // handle error
}

stan, err := f.String()
if err != nil {
    // handle error
}

// Route or log based on MTI and STAN
fmt.Printf("MTI: %s, STAN: %s\n", mti, stan)
```