### PR TITLE
fix(composite): return error on truncated unknown TLV value instead of panicking (#415)

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -684,6 +684,9 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, string, error) {
 
 				// store unknown field as Binary if StoreUnknownTLVTags is enabled
 				if f.spec.Tag.StoreUnknownTLVTags {
+					if offset+read+fieldLength > len(data) {
+						return 0, tag, fmt.Errorf("not enough data to unpack unknown TLV tag %s: need %d bytes, have %d", tag, fieldLength, len(data)-offset-read)
+					}
 					fieldData := data[offset+read : offset+read+fieldLength]
 					binaryField := NewBinary(&Spec{
 						Length:      fieldLength,

--- a/field/composite.go
+++ b/field/composite.go
@@ -684,7 +684,7 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, string, error) {
 
 				// store unknown field as Binary if StoreUnknownTLVTags is enabled
 				if f.spec.Tag.StoreUnknownTLVTags {
-					if offset+read+fieldLength > len(data) {
+					if fieldLength < 0 || fieldLength > len(data)-offset-read {
 						return 0, tag, fmt.Errorf("not enough data to unpack unknown TLV tag %s: need %d bytes, have %d", tag, fieldLength, len(data)-offset-read)
 					}
 					fieldData := data[offset+read : offset+read+fieldLength]

--- a/field/composite_unknown_tlv_test.go
+++ b/field/composite_unknown_tlv_test.go
@@ -226,3 +226,20 @@ func TestStoreUnknownTLVTagsDisabled(t *testing.T) {
 		require.NotContains(t, subfields, "9F37")
 	})
 }
+
+func TestStoreUnknownTLVTagsTruncated(t *testing.T) {
+	t.Run("Unpack returns an error when an unknown TLV value is longer than the remaining data", func(t *testing.T) {
+		composite := NewComposite(storeUnknownTLVSpec)
+
+		// 9F36 (unknown) declares length 4 but only 2 value bytes follow.
+		inputData := []byte{
+			0x30, 0x31, 0x30, // ASCII "010" - length prefix
+			0x9a, 0x03, 0x21, 0x07, 0x20, // 9A: length 3, value 210720
+			0x9f, 0x36, 0x04, 0x01, 0x57, // 9F36: declares length 4 but only 2 bytes remain
+		}
+
+		_, err := composite.Unpack(inputData)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not enough data to unpack unknown TLV tag")
+	})
+}


### PR DESCRIPTION
When `StoreUnknownTLVTags` is enabled and a malformed message declares an unknown TLV value longer than the remaining bytes, `Composite.Unpack` sliced past the end of the buffer and panicked; it now returns a descriptive error instead. Closes #415.