### PR TITLE
encoding: add LenientASCII encoder for permissive decoding

### DIFF
--- a/encoding/lenient_ascii.go
+++ b/encoding/lenient_ascii.go
@@ -1,0 +1,51 @@
+package encoding
+
+import (
+	"fmt"
+)
+
+var (
+	_            Encoder = (*lenientAsciiEncoder)(nil)
+	LenientASCII         = &lenientAsciiEncoder{}
+)
+
+// LenientASCII is like ASCII but passes bytes > 0x7F through without raising
+// an encoder error. The ISO 8583 spec defines text fields as 7-bit ASCII;
+// the strict ASCII encoder enforces that contract. In practice, however,
+// many real-world counterparties occasionally inject non-ASCII bytes into
+// text fields (legacy peers using cp1252, copy-paste artifacts from Word or
+// Excel, uninitialized buffers, or test harnesses that intentionally emit
+// invalid payloads to verify the receiver's format-error path). When that
+// happens, the strict ASCII encoder fails Unpack and the connection layer
+// silently drops the whole message — preventing the application from
+// replying with a proper response (e.g. ISO 8583 RC 30 Format Error) that
+// echoes the original STAN/RRN.
+//
+// LenientASCII lets the message reach the application handler so it can
+// inspect the offending field, decide how to respond, and reply with the
+// echoed fields intact. Content validation (rejecting non-ASCII, control
+// characters, or other domain-specific rules) is the caller's responsibility
+// and should be performed in the handler, not the encoder.
+//
+// Use LenientASCII for fields where you want robust receive behavior over
+// strict spec compliance. Continue using ASCII for fields where any
+// non-ASCII byte should hard-fail at the encoder layer.
+type lenientAsciiEncoder struct{}
+
+func (e lenientAsciiEncoder) Encode(data []byte) ([]byte, error) {
+	out := append([]byte(nil), data...)
+	return out, nil
+}
+
+func (e lenientAsciiEncoder) Decode(data []byte, length int) ([]byte, int, error) {
+	if length < 0 {
+		return nil, 0, fmt.Errorf("invalid length: %d", length)
+	}
+
+	if len(data) < length {
+		return nil, 0, fmt.Errorf("not enough data to decode. expected len %d, got %d", length, len(data))
+	}
+
+	out := append([]byte(nil), data[:length]...)
+	return out, length, nil
+}

--- a/encoding/lenient_ascii.go
+++ b/encoding/lenient_ascii.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-	_            Encoder = (*lenientAsciiEncoder)(nil)
-	LenientASCII         = &lenientAsciiEncoder{}
+	_            Encoder = (*lenientASCIIEncoder)(nil)
+	LenientASCII         = &lenientASCIIEncoder{}
 )
 
 // LenientASCII is like ASCII but passes bytes > 0x7F through without raising
@@ -30,22 +30,31 @@ var (
 // Use LenientASCII for fields where you want robust receive behavior over
 // strict spec compliance. Continue using ASCII for fields where any
 // non-ASCII byte should hard-fail at the encoder layer.
-type lenientAsciiEncoder struct{}
+type lenientASCIIEncoder struct{}
 
-func (e lenientAsciiEncoder) Encode(data []byte) ([]byte, error) {
-	out := append([]byte(nil), data...)
+func (e lenientASCIIEncoder) Encode(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := make([]byte, len(data))
+	copy(out, data)
 	return out, nil
 }
 
-func (e lenientAsciiEncoder) Decode(data []byte, length int) ([]byte, int, error) {
+func (e lenientASCIIEncoder) Decode(data []byte, length int) ([]byte, int, error) {
 	if length < 0 {
 		return nil, 0, fmt.Errorf("invalid length: %d", length)
+	}
+
+	if length == 0 {
+		return nil, 0, nil
 	}
 
 	if len(data) < length {
 		return nil, 0, fmt.Errorf("not enough data to decode. expected len %d, got %d", length, len(data))
 	}
 
-	out := append([]byte(nil), data[:length]...)
+	out := make([]byte, length)
+	copy(out, data[:length])
 	return out, length, nil
 }

--- a/encoding/lenient_ascii_test.go
+++ b/encoding/lenient_ascii_test.go
@@ -1,0 +1,174 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLenientASCII(t *testing.T) {
+	enc := &lenientAsciiEncoder{}
+
+	t.Run("Decode plain ASCII passes through unchanged", func(t *testing.T) {
+		res, read, err := enc.Decode([]byte("hello"), 5)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), res)
+		require.Equal(t, 5, read)
+	})
+
+	t.Run("Decode passes bytes > 0x7F through without error", func(t *testing.T) {
+		// Latin-1 / cp1252 punctuation that strict ASCII rejects:
+		//   0xBB = » (right-pointing double angle quotation mark)
+		//   0xF5 = õ (Latin small letter o with tilde)
+		//   0x9F = Ÿ (Latin capital letter Y with diaeresis, cp1252)
+		//   0x80 = € (euro sign, cp1252)
+		data := []byte{'a', 0xBB, 'b', 0xF5, 'c', 0x9F, 'd', 0x80, 'e'}
+
+		res, read, err := enc.Decode(data, len(data))
+
+		require.NoError(t, err)
+		require.Equal(t, data, res)
+		require.Equal(t, len(data), read)
+	})
+
+	t.Run("Decode passes UTF-8 multibyte through without error", func(t *testing.T) {
+		// "hello, 世界!" — Chinese characters encoded as UTF-8 multibyte
+		// sequences; every continuation byte has bit 7 set.
+		data := []byte("hello, 世界!")
+
+		res, read, err := enc.Decode(data, len(data))
+
+		require.NoError(t, err)
+		require.Equal(t, data, res)
+		require.Equal(t, len(data), read)
+	})
+
+	t.Run("Decode reads only length bytes", func(t *testing.T) {
+		res, read, err := enc.Decode([]byte("hello world"), 5)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), res)
+		require.Equal(t, 5, read)
+	})
+
+	t.Run("Decode preserves control characters", func(t *testing.T) {
+		data := []byte{0x00, 0x01, 0x1F, 0x7F}
+
+		res, read, err := enc.Decode(data, len(data))
+
+		require.NoError(t, err)
+		require.Equal(t, data, res)
+		require.Equal(t, len(data), read)
+	})
+
+	t.Run("Decode errors when length is negative", func(t *testing.T) {
+		_, _, err := enc.Decode([]byte("hello"), -1)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid length: -1")
+	})
+
+	t.Run("Decode errors when data shorter than length", func(t *testing.T) {
+		_, _, err := enc.Decode([]byte("hello"), 6)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to decode. expected len 6, got 5")
+	})
+
+	t.Run("Decode errors when input is nil and length > 0", func(t *testing.T) {
+		_, _, err := enc.Decode(nil, 6)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to decode. expected len 6, got 0")
+	})
+
+	t.Run("Decode returns empty slice when length is zero", func(t *testing.T) {
+		res, read, err := enc.Decode([]byte("hello"), 0)
+
+		require.NoError(t, err)
+		require.Empty(t, res)
+		require.Equal(t, 0, read)
+	})
+
+	t.Run("Encode plain ASCII passes through unchanged", func(t *testing.T) {
+		res, err := enc.Encode([]byte("hello"))
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), res)
+	})
+
+	t.Run("Encode passes bytes > 0x7F through without error", func(t *testing.T) {
+		data := []byte{'a', 0xBB, 'b', 0xF5, 'c', 0x9F, 'd', 0x80, 'e'}
+
+		res, err := enc.Encode(data)
+
+		require.NoError(t, err)
+		require.Equal(t, data, res)
+	})
+
+	t.Run("Encode passes UTF-8 multibyte through without error", func(t *testing.T) {
+		data := []byte("hello, 世界!")
+
+		res, err := enc.Encode(data)
+
+		require.NoError(t, err)
+		require.Equal(t, data, res)
+	})
+
+	t.Run("Encode returns empty slice when input is empty", func(t *testing.T) {
+		res, err := enc.Encode([]byte{})
+
+		require.NoError(t, err)
+		require.Empty(t, res)
+	})
+
+	t.Run("Encode returns a copy independent of the input", func(t *testing.T) {
+		// Mutating the input after Encode must not affect the returned slice.
+		data := []byte("hello")
+		res, err := enc.Encode(data)
+		require.NoError(t, err)
+
+		data[0] = 'x'
+		require.Equal(t, []byte("hello"), res)
+	})
+
+	t.Run("Decode returns a copy independent of the input", func(t *testing.T) {
+		data := []byte("hello")
+		res, _, err := enc.Decode(data, 5)
+		require.NoError(t, err)
+
+		data[0] = 'x'
+		require.Equal(t, []byte("hello"), res)
+	})
+}
+
+func TestLenientASCIISingleton(t *testing.T) {
+	// LenientASCII must satisfy the Encoder interface and be safe to use as
+	// a shared, immutable singleton (consistent with ASCII, Binary, etc.).
+	var _ Encoder = LenientASCII
+
+	a, err := LenientASCII.Encode([]byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), a)
+
+	b, _, err := LenientASCII.Decode([]byte("abc"), 3)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), b)
+}
+
+func FuzzDecodeLenientASCII(f *testing.F) {
+	enc := &lenientAsciiEncoder{}
+
+	f.Fuzz(func(t *testing.T, data []byte, length int) {
+		enc.Decode(data, length)
+	})
+}
+
+func FuzzEncodeLenientASCII(f *testing.F) {
+	enc := &lenientAsciiEncoder{}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		enc.Encode(data)
+	})
+}

--- a/encoding/lenient_ascii_test.go
+++ b/encoding/lenient_ascii_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLenientASCII(t *testing.T) {
-	enc := &lenientAsciiEncoder{}
+	enc := &lenientASCIIEncoder{}
 
 	t.Run("Decode plain ASCII passes through unchanged", func(t *testing.T) {
 		res, read, err := enc.Decode([]byte("hello"), 5)
@@ -158,7 +158,7 @@ func TestLenientASCIISingleton(t *testing.T) {
 }
 
 func FuzzDecodeLenientASCII(f *testing.F) {
-	enc := &lenientAsciiEncoder{}
+	enc := &lenientASCIIEncoder{}
 
 	f.Fuzz(func(t *testing.T, data []byte, length int) {
 		enc.Decode(data, length)
@@ -166,7 +166,7 @@ func FuzzDecodeLenientASCII(f *testing.F) {
 }
 
 func FuzzEncodeLenientASCII(f *testing.F) {
-	enc := &lenientAsciiEncoder{}
+	enc := &lenientASCIIEncoder{}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		enc.Encode(data)


### PR DESCRIPTION
## What

Adds `encoding.LenientASCII`, parallel in style to `ASCII` and `Binary`.
Behaves identically to `ASCII` for 7-bit input, but does not error on
bytes `> 0x7F`. Spec authors opt in per field; strict fields keep using
`encoding.ASCII`.

## Tests

- 15 sub-tests covering Encode + Decode happy paths, edge cases, copy
  independence, empty input, negative length, short data
- 2 fuzz cases: `FuzzDecodeLenientASCII`, `FuzzEncodeLenientASCII`
- `go test ./encoding/... -cover` → 92.1%

## Non-goals

- No change to `encoding.ASCII`
- No change to the `Encoder` interface
- No change to `iso8583-connection`
