### PR TITLE
feat(composite): add TagSpec.Prefix to support Tag Class Character (TCC)

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -1,6 +1,7 @@
 package field
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -500,6 +501,11 @@ func (f *Composite) packByTag() ([]byte, error) {
 		return nil, errors.New("cannot pack composite field by tag when Tag spec is not defined")
 	}
 
+	// prepend tag prefix (e.g. TCC byte) only if there are subfields to pack
+	if len(f.spec.Tag.Prefix) > 0 && len(f.subfields) > 0 {
+		packed = append(packed, f.spec.Tag.Prefix...)
+	}
+
 	for _, tag := range orderedKeys(f.subfields, f.spec.Tag.Sort) {
 		field := f.subfields[tag]
 
@@ -646,6 +652,23 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, string, error) {
 	f.subfields = make(map[string]Field)
 
 	offset := 0
+
+	// read and validate tag prefix (e.g. TCC byte) before the first tag
+	if len(f.spec.Tag.Prefix) > 0 {
+		// empty data is valid — no subfields to unpack
+		if len(data) == 0 {
+			return 0, "", nil
+		}
+		if len(data) < len(f.spec.Tag.Prefix) {
+			return 0, "", fmt.Errorf("data too short for tag prefix: need %d bytes, got %d",
+				len(f.spec.Tag.Prefix), len(data))
+		}
+		if !bytes.Equal(data[:len(f.spec.Tag.Prefix)], f.spec.Tag.Prefix) {
+			return 0, "", fmt.Errorf("unexpected tag prefix: got %X, want %X",
+				data[:len(f.spec.Tag.Prefix)], f.spec.Tag.Prefix)
+		}
+		offset = len(f.spec.Tag.Prefix)
+	}
 
 	for offset < len(data) {
 		tagBytes, read, err := f.spec.Tag.Enc.Decode(data[offset:], f.spec.Tag.Length)

--- a/field/composite_test.go
+++ b/field/composite_test.go
@@ -2372,4 +2372,209 @@ var (
 			"54": NewComposite(field54),
 		},
 	}
+
+	// EBCDIC tag spec with TCC prefix, simulating Mastercard DE 48 structure:
+	// [TCC(0xE3='T')][Tag][Len][Value]...
+	compositeTestSpecWithTagPrefix = &Spec{
+		Length:      999,
+		Description: "Test Spec with Tag Prefix (TCC)",
+		Pref:        prefix.ASCII.LLL,
+		Tag: &TagSpec{
+			Length: 2,               // 2-byte fixed EBCDIC tag
+			Enc:    encoding.EBCDIC, // EBCDIC tag encoding
+			Sort:   sort.StringsByInt,
+			Prefix: []byte{0xE3}, // EBCDIC 'T' — TCC
+		},
+		Subfields: map[string]Field{
+			"87": NewString(&Spec{
+				Length:      3,
+				Description: "Field 87",
+				Enc:         encoding.EBCDIC,
+				Pref:        prefix.EBCDIC.LL,
+			}),
+			"92": NewString(&Spec{
+				Length:      3,
+				Description: "Field 92",
+				Enc:         encoding.EBCDIC,
+				Pref:        prefix.EBCDIC.LL,
+			}),
+		},
+	}
+
+	// EBCDIC tag spec without TCC prefix but with tag padding (for comparison)
+	compositeTestSpecWithEBCDICTags = &Spec{
+		Length:      999,
+		Description: "Test Spec with EBCDIC Tags",
+		Pref:        prefix.ASCII.LLL,
+		Tag: &TagSpec{
+			Length: 2,
+			Enc:    encoding.EBCDIC,
+			Sort:   sort.StringsByInt,
+		},
+		Subfields: map[string]Field{
+			"87": NewString(&Spec{
+				Length:      3,
+				Description: "Field 87",
+				Enc:         encoding.EBCDIC,
+				Pref:        prefix.EBCDIC.LL,
+			}),
+			"92": NewString(&Spec{
+				Length:      3,
+				Description: "Field 92",
+				Enc:         encoding.EBCDIC,
+				Pref:        prefix.EBCDIC.LL,
+			}),
+		},
+	}
 )
+
+type EBCDICTagTestData struct {
+	F87 *String
+	F92 *String
+}
+
+func TestCompositePackingWithTagPrefix(t *testing.T) {
+	t.Run("Pack prepends tag prefix (TCC) before tags", func(t *testing.T) {
+		data := &EBCDICTagTestData{
+			F87: NewStringValue("ABC"),
+			F92: NewStringValue("XYZ"),
+		}
+
+		composite := NewComposite(compositeTestSpecWithTagPrefix)
+		err := composite.Marshal(data)
+		require.NoError(t, err)
+
+		packed, err := composite.Pack()
+		require.NoError(t, err)
+
+		// Manual verification of the structure:
+		// Length prefix (ASCII LLL): "015"
+		// TCC: 0xE3
+		// Tag 87: EBCDIC('8','7') = 0xF8, 0xF7
+		// Len 87 (EBCDIC LL=3): EBCDIC('0','3') = 0xF0, 0xF3
+		// Value 87: EBCDIC('A','B','C') = 0xC1, 0xC2, 0xC3
+		// Tag 92: EBCDIC('9','2') = 0xF9, 0xF2
+		// Len 92 (EBCDIC LL=3): EBCDIC('0','3') = 0xF0, 0xF3
+		// Value 92: EBCDIC('X','Y','Z') = 0xE7, 0xE8, 0xE9
+		expected := []byte{
+			0x30, 0x31, 0x35, // ASCII LLL "015"
+			0xE3,       // TCC 'T'
+			0xF8, 0xF7, // EBCDIC tag "87"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xC1, 0xC2, 0xC3, // EBCDIC "ABC"
+			0xF9, 0xF2, // EBCDIC tag "92"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xE7, 0xE8, 0xE9, // EBCDIC "XYZ"
+		}
+		require.Equal(t, expected, packed)
+	})
+
+	t.Run("Unpack reads and validates tag prefix", func(t *testing.T) {
+		raw := []byte{
+			0x30, 0x31, 0x35, // ASCII LLL "015"
+			0xE3,       // TCC 'T'
+			0xF8, 0xF7, // EBCDIC tag "87"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xC1, 0xC2, 0xC3, // EBCDIC "ABC"
+			0xF9, 0xF2, // EBCDIC tag "92"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xE7, 0xE8, 0xE9, // EBCDIC "XYZ"
+		}
+
+		composite := NewComposite(compositeTestSpecWithTagPrefix)
+		read, err := composite.Unpack(raw)
+		require.NoError(t, err)
+		require.Equal(t, len(raw), read)
+
+		data := &EBCDICTagTestData{}
+		require.NoError(t, composite.Unmarshal(data))
+		require.Equal(t, "ABC", data.F87.Value())
+		require.Equal(t, "XYZ", data.F92.Value())
+	})
+
+	t.Run("Unpack returns error on wrong tag prefix", func(t *testing.T) {
+		// Provide correct total length so the outer length check passes,
+		// but with wrong TCC byte to trigger the inner prefix validation.
+		raw := []byte{
+			0x30, 0x31, 0x35, // ASCII LLL "015" (15 bytes of content)
+			0x00,       // WRONG TCC (should be 0xE3)
+			0xF8, 0xF7, // EBCDIC tag "87"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xC1, 0xC2, 0xC3, // EBCDIC "ABC"
+			0xF9, 0xF2, // EBCDIC tag "92"
+			0xF0, 0xF3, // EBCDIC len "03"
+			0xE7, 0xE8, 0xE9, // EBCDIC "XYZ"
+		}
+
+		composite := NewComposite(compositeTestSpecWithTagPrefix)
+		_, err := composite.Unpack(raw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected tag prefix")
+	})
+
+	t.Run("Unpack returns error when data too short for tag prefix", func(t *testing.T) {
+		// 2-byte prefix, data only has 1 byte
+		spec := &Spec{
+			Length: 999,
+			Pref:   prefix.ASCII.LLL,
+			Tag: &TagSpec{
+				Length: 2,
+				Enc:    encoding.ASCII,
+				Sort:   sort.StringsByInt,
+				Prefix: []byte{0xE3, 0xE4}, // 2-byte prefix
+			},
+			Subfields: map[string]Field{
+				"87": NewString(&Spec{
+					Length: 3,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.LL,
+				}),
+			},
+		}
+		composite := NewComposite(spec)
+		err := composite.SetBytes([]byte{0xE3}) // only 1 byte, need 2
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data too short for tag prefix")
+	})
+
+	t.Run("Unpack empty data with prefix succeeds", func(t *testing.T) {
+		// Empty content should succeed and reset subfields
+		// (no subfields to unpack is a valid state)
+		composite := NewComposite(compositeTestSpecWithTagPrefix)
+		err := composite.SetBytes([]byte{})
+		require.NoError(t, err)
+		require.Empty(t, composite.GetSubfields())
+	})
+
+	t.Run("Pack with empty subfields omits prefix", func(t *testing.T) {
+		// When no subfields are set, prefix should not be written
+		composite := NewComposite(compositeTestSpecWithTagPrefix)
+		packed, err := composite.Pack()
+		require.NoError(t, err)
+		// Should be just length prefix "000" for 0 content bytes
+		expected := []byte{0x30, 0x30, 0x30}
+		require.Equal(t, expected, packed)
+	})
+	t.Run("Pack with EBCDIC tags works without prefix", func(t *testing.T) {
+		// Verify that without prefix the EBCDIC tag spec still works correctly
+		data := &EBCDICTagTestData{
+			F87: NewStringValue("HI"),
+		}
+
+		composite := NewComposite(compositeTestSpecWithEBCDICTags)
+		err := composite.Marshal(data)
+		require.NoError(t, err)
+
+		packed, err := composite.Pack()
+		require.NoError(t, err)
+
+		// Tag87(2) + Len87(2) + "HI"(2) = 6 bytes content
+		expected := []byte{
+			0x30, 0x30, 0x36, // ASCII LLL "006"
+			0xF8, 0xF7, // EBCDIC tag "87"
+			0xF0, 0xF2, // EBCDIC len "02"
+			0xC8, 0xC9, // EBCDIC "HI"
+		}
+		require.Equal(t, expected, packed)
+	})
+}

--- a/field/spec.go
+++ b/field/spec.go
@@ -44,6 +44,13 @@ type TagSpec struct {
 	StoreUnknownTLVTags bool
 	// PrefUnknownTLV is used for skipping unknown TLV if it is not nil
 	PrefUnknownTLV prefix.Prefixer
+	// Prefix is an optional byte sequence in wire format that appears once
+	// before all tag-value pairs in the composite field content. It is
+	// commonly used for Tag Class Characters (TCC) in protocols like
+	// Mastercard DE 48, where a framing byte (e.g., EBCDIC 'T' = 0xE3)
+	// precedes the TLV structure to indicate the tag encoding scheme.
+	// This only applies to tagged composites (Tag.Enc != nil).
+	Prefix []byte
 }
 
 // Spec defines the structure of a field.


### PR DESCRIPTION
## Summary

Some ISO 8583 implementations, such as **Mastercard DE 48**, use a Tag Class Character (TCC) byte (e.g., EBCDIC `T` = `0xE3`) that precedes all tag-value pairs in a composite field. The TCC indicates the tag encoding scheme for the entire TLV structure.

Previously, there was no way to handle this at the framework level — users had to manually prepend/strip the TCC byte outside of the Composite field, breaking encapsulation.

## Changes

- Add `Prefix []byte` field to `TagSpec` for wire-format bytes before tag-value pairs
- `packByTag()`: write prefix before the first tag-value pair
- `unpackSubfieldsByTag()`: read and validate prefix before decoding tags
- Add test coverage: pack, unpack, wrong prefix error, too-short data, backward compatibility (prefix=nil)

## Usage

```go
Spec{
    Tag: &TagSpec{
        Length: 2,               // fixed EBCDIC tag length
        Enc:    encoding.EBCDIC, // EBCDIC tag encoding
        Sort:   sort.StringsByInt,
        Prefix: []byte{0xE3},   // EBCDIC "T" — TCC
    },
    Subfields: map[string]Field{...},
}
```

## Checklist

- [x] `go build` passes
- [x] `go test ./...` passes (all 13 packages)
- [x] `go vet ./field/...` clean
- [x] `gofmt` no diffs
- [x] `gitleaks` no leaks
- [x] Test coverage: 84.0% (threshold: 75%)
- [x] Backward compatible (prefix=nil preserves existing behavior)