### PR TITLE
test(fuzz): add native Go fuzzers for Unpack/Pack and MessageScanner

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,51 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test . -fuzz FuzzUnpackPackSpec87 -fuzztime 10m"
+          - "go test . -fuzz FuzzUnpackPackSpec87ASCII -fuzztime 10m"
+          - "go test . -fuzz FuzzMessageScanner -fuzztime 10m"
+          - "go test . -fuzz FuzzUnpack -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeASCII -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeBCD -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeLBCD -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeEBCDIC -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeEBCDIC1047 -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeBinary -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeBerTLV -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeBytesToASCIIHex -fuzztime 10m"
+          - "go test ./encoding -fuzz FuzzDecodeASCIIHexToBytes -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,99 @@
+package iso8583_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/iso8583"
+	"github.com/moov-io/iso8583/specs"
+)
+
+func FuzzUnpackPackSpec87(f *testing.F) {
+	populateISOCorpus(f)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		msg := iso8583.NewMessage(iso8583.Spec87)
+		if err := msg.Unpack(data); err != nil {
+			return
+		}
+		packed, err := msg.Pack()
+		if err != nil {
+			return
+		}
+		// Re-unpack packed bytes — must not panic
+		msg2 := iso8583.NewMessage(iso8583.Spec87)
+		_ = msg2.Unpack(packed)
+		_, _ = msg.MarshalJSON()
+	})
+}
+
+func FuzzUnpackPackSpec87ASCII(f *testing.F) {
+	populateISOCorpus(f)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		msg := iso8583.NewMessage(specs.Spec87ASCII)
+		if err := msg.Unpack(data); err != nil {
+			return
+		}
+		_, _ = msg.Pack()
+		_, _ = msg.MarshalJSON()
+	})
+}
+
+func FuzzMessageScanner(f *testing.F) {
+	populateISOCorpus(f)
+
+	// Common field IDs to probe with the forward-only scanner
+	fieldIDs := []int{0, 2, 3, 4, 7, 11, 39, 41, 49}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip()
+		}
+
+		scanner := iso8583.NewMessageScanner(iso8583.Spec87, data)
+		for _, id := range fieldIDs {
+			_, _ = scanner.ScanField(id)
+		}
+	})
+}
+
+func populateISOCorpus(f *testing.F) {
+	f.Helper()
+
+	f.Add([]byte{})
+	f.Add([]byte("0800"))
+	f.Add([]byte("080082200000000000000400000000000000123456789012"))
+
+	roots := []string{
+		filepath.Join("test", "testdata"),
+		filepath.Join("test", "fuzz-reader", "corpus"),
+		filepath.Join("testdata"),
+	}
+	for _, root := range roots {
+		_ = filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+			if err != nil || info == nil || info.IsDir() {
+				return nil
+			}
+			ext := filepath.Ext(path)
+			if ext == ".dat" || ext == "" || ext == ".bin" {
+				bs, err := os.ReadFile(path)
+				if err != nil || len(bs) > 64*1024 {
+					return nil
+				}
+				f.Add(bs)
+			}
+			return nil
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add native Go fuzz tests for Spec87 / Spec87ASCII unpack-pack round trips and MessageScanner field probing. Seeds include `test/testdata` `.dat` samples and the existing go-fuzz corpus under `test/fuzz-reader/corpus`.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing