### PR TITLE
fix(composite): bounds-check unknown TLV length in skip path

### DIFF
--- a/field/composite.go
+++ b/field/composite.go
@@ -682,11 +682,12 @@ func (f *Composite) unpackSubfieldsByTag(data []byte) (int, string, error) {
 					return 0, "", err
 				}
 
+				if fieldLength < 0 || fieldLength > len(data)-offset-read {
+					return 0, tag, fmt.Errorf("not enough data to unpack unknown TLV tag %s: need %d bytes, have %d", tag, fieldLength, len(data)-offset-read)
+				}
+
 				// store unknown field as Binary if StoreUnknownTLVTags is enabled
 				if f.spec.Tag.StoreUnknownTLVTags {
-					if fieldLength < 0 || fieldLength > len(data)-offset-read {
-						return 0, tag, fmt.Errorf("not enough data to unpack unknown TLV tag %s: need %d bytes, have %d", tag, fieldLength, len(data)-offset-read)
-					}
 					fieldData := data[offset+read : offset+read+fieldLength]
 					binaryField := NewBinary(&Spec{
 						Length:      fieldLength,

--- a/field/composite_unknown_tlv_repro_test.go
+++ b/field/composite_unknown_tlv_repro_test.go
@@ -1,0 +1,46 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipUnknownTLVTagsMalformedLength(t *testing.T) {
+	spec := &Spec{
+		Length:      999,
+		Description: "TLV skip-only",
+		Pref:        prefix.ASCII.LLL,
+		Tag: &TagSpec{
+			Enc:                 encoding.BerTLVTag,
+			Sort:                sort.StringsByHex,
+			SkipUnknownTLVTags:  true,
+			StoreUnknownTLVTags: false,
+		},
+		Subfields: map[string]Field{
+			"9F02": NewHex(&Spec{
+				Description: "Amount, Authorized (Numeric)",
+				Enc:         encoding.Binary,
+				Pref:        prefix.BerTLV,
+			}),
+		},
+	}
+
+	composite := NewComposite(spec)
+
+	// 8A is an unknown tag. Its BER-TLV length uses the long form with 8
+	// length bytes encoding 2^63, which decodes to a negative int.
+	inputData := []byte{
+		0x30, 0x31, 0x30, // ASCII "010" length prefix
+		0x8A,                                           // unknown tag (1 byte)
+		0x88,                                           // long form: 8 length bytes follow
+		0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 2^63
+	}
+
+	_, err := composite.Unpack(inputData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not enough data to unpack unknown TLV tag")
+}


### PR DESCRIPTION
## What

`Composite.unpackSubfieldsByTag` panics with `slice bounds out of range` when unpacking a BER-TLV composite with `SkipUnknownTLVTags` enabled and `StoreUnknownTLVTags` disabled, if an unknown tag carries a crafted long-form length.

## Why

The bounds check on the decoded unknown-tag length only ran inside the `StoreUnknownTLVTags` branch. In the skip-only path, `offset += fieldLength + read` ran unchecked. A BER-TLV long-form length of 8 bytes encoding 2^63 decodes to math.MinInt64 (via big.Int.Int64() in prefix.BerTLV.DecodeLength), driving offset negative; the next loop iteration panics on `data[offset:]`. A large positive length can also overflow the offset computation for the same effect.

Panic at master (0683146):

```
panic: runtime error: slice bounds out of range [-9223372036854775798:]
github.com/moov-io/iso8583/field.(*Composite).unpackSubfieldsByTag(...)
	 field/composite.go:651
```

## How

Move the existing bounds check (introduced for the store path in #416) up so it runs right after DecodeLength, covering both the store and skip paths, and return the existing "not enough data to unpack unknown TLV tag" error instead of panicking. No behavior change for valid messages.

Adds a regression test feeding an unknown tag with a long-form length encoding 2^63.

## Verification

- New regression test panics without the fix and passes with it (error returned, no panic).
- `go test ./...` passes for all packages.
- `go vet ./field/` and `gofmt` are clean.

Closes #426

Made with [Cursor](https://cursor.com)