### PR TITLE
fix(specs): register missing field types and encodings in the spec builder

### DIFF
--- a/specs/builder.go
+++ b/specs/builder.go
@@ -30,6 +30,9 @@ var (
 		"Binary":    func(spec *field.Spec) field.Field { return field.NewBinary(spec) },
 		"Bitmap":    func(spec *field.Spec) field.Field { return field.NewBitmap(spec) },
 		"Composite": func(spec *field.Spec) field.Field { return field.NewComposite(spec) },
+		"Hex":       func(spec *field.Spec) field.Field { return field.NewHex(spec) },
+		"Track1":    func(spec *field.Spec) field.Field { return field.NewTrack1(spec) },
+		"Track3":    func(spec *field.Spec) field.Field { return field.NewTrack3(spec) },
 	}
 
 	PrefixesExtToInt = map[string]prefix.Prefixer{
@@ -71,6 +74,7 @@ var (
 		"ASCIIToHex": encoding.ASCIIHexToBytes,
 		"LBCD":       encoding.LBCD,
 		"BerTLVTag":  encoding.BerTLVTag,
+		"EBCDIC1047": encoding.EBCDIC1047,
 	}
 
 	EncodingsIntToExt = map[string]string{
@@ -81,6 +85,8 @@ var (
 		"hexToASCIIEncoder": "HexToASCII",
 		"asciiToHexEncoder": "ASCIIToHex",
 		"lBCDEncoder":       "LBCD",
+		"berTLVEncoderTag":  "BerTLVTag",
+		"ebcdic1047Encoder": "EBCDIC1047",
 	}
 
 	PaddersIntToExt = map[string]string{

--- a/specs/builder_test.go
+++ b/specs/builder_test.go
@@ -499,3 +499,166 @@ func TestExportImportWithNonePrefixField(t *testing.T) {
 	spec, err = ImportJSON(specJSON)
 	require.NoError(t, err)
 }
+
+// Export names field types with reflection, so any field type in the library
+// can be written to a spec document, while import resolves them through
+// FieldConstructor. This pins the round trip for every field type so the two
+// directions cannot drift apart.
+func TestExportImportAllFieldTypes(t *testing.T) {
+	spec := &iso8583.MessageSpec{
+		Name: "all field types",
+		Fields: map[int]field.Field{
+			0: field.NewString(&field.Spec{
+				Length:      4,
+				Description: "Message Type Indicator",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			1: field.NewBitmap(&field.Spec{
+				Length:      16,
+				Description: "Bitmap",
+				Enc:         encoding.BytesToASCIIHex,
+				Pref:        prefix.Hex.Fixed,
+			}),
+			2: field.NewNumeric(&field.Spec{
+				Length:      19,
+				Description: "Primary Account Number",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			3: field.NewBinary(&field.Spec{
+				Length:      8,
+				Description: "Binary field",
+				Enc:         encoding.Binary,
+				Pref:        prefix.Binary.Fixed,
+			}),
+			52: field.NewHex(&field.Spec{
+				Length:      8,
+				Description: "PIN Data",
+				Enc:         encoding.Binary,
+				Pref:        prefix.Binary.Fixed,
+			}),
+			35: field.NewTrack2(&field.Spec{
+				Length:      37,
+				Description: "Track 2 Data",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			36: field.NewTrack3(&field.Spec{
+				Length:      104,
+				Description: "Track 3 Data",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LLL,
+			}),
+			45: field.NewTrack1(&field.Spec{
+				Length:      76,
+				Description: "Track 1 Data",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+		},
+	}
+
+	jsonData, err := ExportJSON(spec)
+	require.NoError(t, err)
+
+	fromJSON, err := ImportJSON(jsonData)
+	require.NoError(t, err)
+	require.Exactly(t, spec, fromJSON)
+
+	yamlData, err := ExportYAML(spec)
+	require.NoError(t, err)
+
+	fromYAML, err := ImportYAML(yamlData)
+	require.NoError(t, err)
+	require.Exactly(t, spec, fromYAML)
+}
+
+// emvICCDataSpecYAML is a BER-TLV composite as it appears in a real spec
+// document. It exercises the composite tag encoding and Hex subfields
+// together, which is how EMV data is described.
+const emvICCDataSpecYAML = `name: EMV ICC Data
+fields:
+    "55":
+        type: Composite
+        length: 999
+        description: ICC Data, EMV having multiple tags
+        prefix: ASCII.LLL
+        tag:
+            enc: BerTLVTag
+            sort: StringsByHex
+        subfields:
+            "82":
+                type: Hex
+                description: Application Interchange Profile
+                enc: Binary
+                prefix: BerTLV
+            "95":
+                type: Hex
+                description: Terminal Verification Results
+                enc: Binary
+                prefix: BerTLV
+            "9A":
+                type: Hex
+                description: Transaction Date
+                enc: Binary
+                prefix: BerTLV
+            "9F02":
+                type: Hex
+                description: Amount, Authorized
+                enc: Binary
+                prefix: BerTLV
+            "9F26":
+                type: Hex
+                description: Application Cryptogram
+                enc: Binary
+                prefix: BerTLV
+            "9F36":
+                type: Hex
+                description: Application Transaction Counter
+                enc: Binary
+                prefix: BerTLV
+`
+
+func TestImportExportEMVCompositeSpec(t *testing.T) {
+	spec, err := ImportYAML([]byte(emvICCDataSpecYAML))
+	require.NoError(t, err)
+
+	iccSpec := spec.Fields[55].Spec()
+	require.Equal(t, encoding.BerTLVTag, iccSpec.Tag.Enc)
+	require.Len(t, iccSpec.Subfields, 6)
+	require.Equal(t, "Application Cryptogram", iccSpec.Subfields["9F26"].Spec().Description)
+
+	exported, err := ExportYAML(spec)
+	require.NoError(t, err)
+
+	// Exporting is stable: importing the exported document and exporting it
+	// again produces the same bytes.
+	reimported, err := ImportYAML(exported)
+	require.NoError(t, err)
+	reexported, err := ExportYAML(reimported)
+	require.NoError(t, err)
+	require.Equal(t, string(exported), string(reexported))
+}
+
+// EBCDIC1047 is resolvable by name on import and by struct name on export.
+func TestExportImportEBCDIC1047Encoding(t *testing.T) {
+	spec := &iso8583.MessageSpec{
+		Name: "ebcdic 1047",
+		Fields: map[int]field.Field{
+			2: field.NewString(&field.Spec{
+				Length:      10,
+				Description: "EBCDIC 1047 field",
+				Enc:         encoding.EBCDIC1047,
+				Pref:        prefix.EBCDIC.Fixed,
+			}),
+		},
+	}
+
+	jsonData, err := ExportJSON(spec)
+	require.NoError(t, err)
+
+	fromJSON, err := ImportJSON(jsonData)
+	require.NoError(t, err)
+	require.Exactly(t, spec, fromJSON)
+}


### PR DESCRIPTION
Closes #429.

## Problem

Export names field types by reflection and so handles every type in the library; import resolves them through `FieldConstructor`, which knows six of nine. The encoding maps have the same asymmetry. Consequences:

- `Hex`, `Track1`, `Track3` can be exported but not imported
- a BER-TLV composite **cannot be exported at all** (`unknown encoding type: berTLVEncoderTag`), so EMV specs cannot be written
- `EBCDIC1047` is registered in neither direction

## Change

Six entries in `specs/builder.go`:

- `FieldConstructor`: `Hex`, `Track1`, `Track3`
- `EncodingsExtToInt`: `EBCDIC1047`
- `EncodingsIntToExt`: `berTLVEncoderTag`, `ebcdic1047Encoder`

The two export keys are the unexported struct names because `exportEnc` uses `reflect.TypeOf(enc).Elem().Name()`, consistent with the existing entries.

## Tests

Three tests in `specs/builder_test.go`, each verified failing before the change:

- `TestExportImportAllFieldTypes`: one field of every type, exact round trip through JSON and YAML
- `TestImportExportEMVCompositeSpec`: imports a realistic DE 55 document with six EMV tags, then checks export is stable across a further round trip
- `TestExportImportEBCDIC1047Encoding`

The EMV fixture is inline in the test rather than a new file under `examples/`, to avoid changing published example specs.

## Verification

`make check` on Linux, unmodified: golangci-lint 0 issues, all packages pass, coverage 80.0% against the 75.0% threshold. Also `go test -race`, `govulncheck` (no vulnerabilities), and the `oldstable` toolchain.

## Alternatives considered

Deriving the registry rather than maintaining it by hand: export can use reflection because it starts from an instance, but import starts from a string, and Go cannot resolve a type from its name at run time. Self-registration via `init()` in each `field` file would create an import cycle, since `specs` imports `field` and not the reverse.

A guard test walking `field/*.go` with `go/parser` would keep the registry from drifting again (#401 adds an encoder that would also go unregistered). Happy to add it, here or separately.
