### PR TITLE
ci(fuzz): raise go test timeout above fuzztime

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,26 +11,29 @@ jobs:
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         command:
           # Anchor patterns with ^...$ so substrings do not match multiple tests
           # (e.g. FuzzUnpack must not also match FuzzUnpackPackSpec87).
-          - "go test . -run=^$ -fuzz=^FuzzUnpackPackSpec87$ -fuzztime 10m"
-          - "go test . -run=^$ -fuzz=^FuzzUnpackPackSpec87ASCII$ -fuzztime 10m"
-          - "go test . -run=^$ -fuzz=^FuzzMessageScanner$ -fuzztime 10m"
-          - "go test . -run=^$ -fuzz=^FuzzUnpack$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeASCII$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBCD$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeLBCD$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeEBCDIC$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeEBCDIC1047$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBinary$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBerTLV$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBytesToASCIIHex$ -fuzztime 10m"
-          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeASCIIHexToBytes$ -fuzztime 10m"
+          # -timeout must exceed -fuzztime; the default 10m test timeout
+          # expires at the same time as fuzztime and fails the job
+          # (context deadline exceeded).
+          - "go test . -run=^$ -fuzz=^FuzzUnpackPackSpec87$ -fuzztime 10m -timeout 20m"
+          - "go test . -run=^$ -fuzz=^FuzzUnpackPackSpec87ASCII$ -fuzztime 10m -timeout 20m"
+          - "go test . -run=^$ -fuzz=^FuzzMessageScanner$ -fuzztime 10m -timeout 20m"
+          - "go test . -run=^$ -fuzz=^FuzzUnpack$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeASCII$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBCD$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeLBCD$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeEBCDIC$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeEBCDIC1047$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBinary$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBerTLV$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeBytesToASCIIHex$ -fuzztime 10m -timeout 20m"
+          - "go test ./encoding -run=^$ -fuzz=^FuzzDecodeASCIIHexToBytes$ -fuzztime 10m -timeout 20m"
 
     steps:
     - name: Set up Go 1.x


### PR DESCRIPTION
## Problem

[FuzzUnpackPackSpec87ASCII](https://github.com/moov-io/iso8583/actions/runs/31918627147/job/95094666027) ran a full 10 minutes of fuzzing, then failed with:

```
--- FAIL: FuzzUnpackPackSpec87ASCII (601.01s)
    context deadline exceeded
```

There was no crashing input. `go test` defaults to `-timeout 10m`, which matches `-fuzztime 10m`, so the test context expires as soon as fuzzing finishes.

## Fix

- Add `-timeout 20m` to every fuzz matrix command.
- Raise the job `timeout-minutes` from 15 to 25 so the runner does not kill a 20m test.

No library change; this job did not produce a failing corpus.