### PR TITLE
docs: add annotated ISO 8583 message examples to Learn more

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ Please, check the example of the JSON spec file [spec87ascii.json](./examples/sp
 - [Mastering ISO 8583 messages with Golang](https://alovak.com/2024/08/15/mastering-iso-8583-messages-with-golang/)
 - [Mastering ISO 8583 Message Networking with Golang](https://alovak.com/2024/08/27/mastering-iso-8583-message-networking-with-golang/)
 - [ISO 8583 Terms and Definitions](https://www.iso.org/obp/ui/#iso:std:iso:8583:-1:ed-1:v1:en)
+- [Annotated ISO 8583 message examples](https://iso8583parser.com/en/articles/iso8583-message-examples)
 
 ## Getting help
 


### PR DESCRIPTION
@alovak — one line added to "Learn more", after the ISO terms link:

`- [Annotated ISO 8583 message examples](https://iso8583parser.com/en/articles/iso8583-message-examples)`

It's 8 messages — authorization request/response, financial request/response, a 0400 reversal with DE90, an 0800/0810 echo, and a chip transaction with DE55 — each annotated field by field. Every one opens pre-decoded in a client-side parser through a `?m=` link, so a reader goes from reading about a bitmap to seeing one taken apart without setting anything up.

Where it complements what's already in the list: when someone defines a new spec with this library and wants to sanity-check their `Pack()` output, running the hex through an independent decoder catches bitmap and length-prefix mistakes quickly. That's a step `docs/intro.md` and `docs/data-elements.md` don't cover.

Disclosure: I built and maintain that site. It's free, no signup, and parsing runs entirely in the browser — nothing is uploaded, so it's safe for real message dumps.

Happy to close this if you'd rather keep "Learn more" to written guides.
