### PR TITLE
fix(specs): return an error instead of panicking on an invalid composite spec

### DIFF
--- a/specs/builder.go
+++ b/specs/builder.go
@@ -161,6 +161,24 @@ type tagDummy struct {
 	PrefUnknownTLV      string        `json:"prefUnknownTLV,omitempty"       xml:"prefUnknownTLV,omitempty"       yaml:"prefUnknownTLV,omitempty"`
 }
 
+// constructField builds a field from its spec, turning a spec-validation panic
+// into an error.
+//
+// Field constructors panic on an invalid spec by design, and for static specs
+// that is the right call: a mistake is a programming error and failing at init
+// beats failing mid-transaction. Import is where that assumption stops holding.
+// The spec arrives as a document at runtime, so a malformed one is bad data
+// rather than a bug, and ImportJSON/ImportYAML already promise an error for it.
+// The panic value carries the specific reason, so it becomes the message.
+func constructField(constructor FieldConstructorFunc, spec *field.Spec, index string) (f field.Field, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("invalid spec for field: %s. %v", index, r)
+		}
+	}()
+	return constructor(spec), nil
+}
+
 func importField(dummyField *fieldDummy, index string) (*field.Spec, error) {
 	fieldSpec := &field.Spec{
 		Length:      dummyField.Length,
@@ -197,7 +215,11 @@ func importField(dummyField *fieldDummy, index string) (*field.Spec, error) {
 			if !ok {
 				return nil, fmt.Errorf("no constructor for filed type: %s for field: %s", dummyField.Type, index)
 			}
-			fieldSpec.Subfields[key] = constructor(subfieldSpec)
+			subfield, err := constructField(constructor, subfieldSpec, key)
+			if err != nil {
+				return nil, err
+			}
+			fieldSpec.Subfields[key] = subfield
 		}
 
 		if dummyField.Tag != nil {
@@ -275,7 +297,11 @@ func importSpec(dummySpec *specDummy) (*iso8583.MessageSpec, error) {
 				index,
 			)
 		}
-		spec.Fields[index] = constructor(fieldSpec)
+		f, err := constructField(constructor, fieldSpec, key)
+		if err != nil {
+			return nil, err
+		}
+		spec.Fields[index] = f
 	}
 
 	return &spec, nil

--- a/specs/builder_test.go
+++ b/specs/builder_test.go
@@ -662,3 +662,65 @@ func TestExportImportEBCDIC1047Encoding(t *testing.T) {
 	require.NoError(t, err)
 	require.Exactly(t, spec, fromJSON)
 }
+
+// An invalid composite spec must be reported, not fatal. Field constructors
+// panic on a bad spec by design, which is right for the static specs in this
+// package but not for a document arriving at runtime: ImportJSON and ImportYAML
+// promise an error, and a malformed file should not take the process with it.
+func TestImportRejectsInvalidCompositeSpecs(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "encoding on a composite",
+			yaml: `
+name: test
+fields:
+  "55": {type: Composite, length: 999, enc: ASCII, prefix: ASCII.LLL}
+`,
+			want: "only supports a nil Enc value",
+		},
+		{
+			name: "neither tag nor bitmap",
+			yaml: `
+name: test
+fields:
+  "55":
+    type: Composite
+    length: 999
+    prefix: ASCII.LLL
+    subfields:
+      "1": {type: String, length: 2, enc: ASCII, prefix: ASCII.Fixed}
+`,
+			want: "definition of Bitmap or Tag",
+		},
+		{
+			name: "padding on a composite",
+			yaml: `
+name: test
+fields:
+  "55":
+    type: Composite
+    length: 999
+    prefix: ASCII.LLL
+    padding: {type: Left, pad: "0"}
+    tag: {enc: BerTLVTag, sort: StringsByInt}
+    subfields:
+      "9F02": {type: String, length: 2, enc: ASCII, prefix: ASCII.Fixed}
+`,
+			want: "nil or None spec padding",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := ImportYAML([]byte(tc.yaml))
+			require.Error(t, err)
+			require.Nil(t, spec)
+			require.Contains(t, err.Error(), tc.want)
+			require.Contains(t, err.Error(), "55")
+		})
+	}
+}


### PR DESCRIPTION
`ImportJSON` and `ImportYAML` both return an `error`, but three shapes of invalid composite reach `Composite.SetSpec` and panic instead, taking the process with them.

Found while importing a hand-written YAML spec: a composite that carried an encoding crashed the caller rather than telling it which field was wrong.

## Reproduction

Each of these panics on `master` today:

```yaml
# 1 — panic: Composite spec only supports a nil Enc value
fields:
  "55": {type: Composite, length: 999, enc: ASCII, prefix: ASCII.LLL}
```

```yaml
# 2 — panic: Composite spec only supports a definition of Bitmap or Tag
fields:
  "55":
    type: Composite
    length: 999
    prefix: ASCII.LLL
    subfields:
      "1": {type: String, length: 2, enc: ASCII, prefix: ASCII.Fixed}
```

```yaml
# 3 — panic: Composite spec only supports nil or None spec padding values
fields:
  "55":
    type: Composite
    length: 999
    prefix: ASCII.LLL
    padding: {type: Left, pad: "0"}
    tag: {enc: BerTLVTag, sort: StringsByInt}
    subfields:
      "9F02": {type: String, length: 2, enc: ASCII, prefix: ASCII.Fixed}
```

The first is the easiest to hit by hand. `importField` decides whether to set `Enc` from the presence of *subfields* rather than from the field *type*. So it hands an encoding to a composite that is not allowed to have one.

The contrast is what prompted this. Drop `enc` from case 1, and the same function reports `unknown encoding: for field: 55`, cleanly. The package handles the same class of malformed document in two different ways.

## The change

A panic on an invalid spec is the right call for the static specs in this package. A mistake there is a programming error, and failing at init beats failing mid-transaction. Import is where that assumption stops holding. The spec arrives as a document at runtime, so a malformed one is bad data.

Restating `Spec.Validate`'s rules at the import boundary would drift from the validator. Instead, this recovers at the two points where a constructor runs, and returns the panic value as the error. The validator's message is already specific, so it becomes the error text, prefixed with the field it came from. A future validation rule needs no further change here.

```
invalid spec for field: 55. Composite spec only supports a nil Enc value
```

## Tests

`TestImportRejectsInvalidCompositeSpecs` in `specs/builder_test.go` covers all three shapes in one table. It pins the consistency itself, not only the encoding case.

Revert `specs/builder.go`, keep the test, and the run panics out on the first subtest. The process dies instead of the assertion failing, which is the behaviour this fixes.

`go test ./...` is green across the module (12 packages). `gofmt` clean.

## Scope

- Nothing that imports successfully today behaves differently. The recover fires only where the process died before.
- `SetSpec`'s own contract does not change. Programmatic callers still get the panic.

Happy to narrow it to case 1 only, or to add the equivalent guard to `ImportXML`, if you would rather keep the surface smaller.

---

*Disclosure: I prepared this patch with AI assistance. I ran the reproduction, the red/green check and the suite above against this branch. Happy to adjust anything on request.*

🤖 Claude Opus 5

