### PR TITLE
fix(specs): refuse to export a sort function the importer cannot resolve

### DIFF
--- a/specs/builder.go
+++ b/specs/builder.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/moov-io/iso8583"
 	"github.com/moov-io/iso8583/encoding"
@@ -402,7 +403,11 @@ func exportTag(tag *field.TagSpec) (*tagDummy, error) {
 		}
 	}
 	if tag.Sort != nil {
-		dummy.Sort = getFunctionName(tag.Sort)
+		name, err := exportSort(tag.Sort)
+		if err != nil {
+			return nil, err
+		}
+		dummy.Sort = name
 	}
 	if tag.PrefUnknownTLV != nil {
 		dummy.PrefUnknownTLV = tag.PrefUnknownTLV.Inspect()
@@ -419,6 +424,30 @@ func exportPad(pad padding.Padder) (*paddingDummy, error) {
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown padding type: %s", paddingType)
+}
+
+// exportSort names a sort function so a spec can be read back. Only the
+// functions ImportJSON and ImportYAML can resolve are nameable: exporting any
+// other one produced a document that the importer then rejected with "unknown
+// sort function", so a custom sort turned a round trip into a file that looked
+// fine and could not be loaded. Failing here puts the error in front of whoever
+// can act on it.
+func exportSort(sort moovsort.StringSlice) (string, error) {
+	name := getFunctionName(sort)
+	if _, ok := SortExtToInt[name]; !ok {
+		return "", fmt.Errorf("unknown sort function: %s; only %s can be exported, "+
+			"because those are the ones an import can resolve", name, knownSortNames())
+	}
+	return name, nil
+}
+
+func knownSortNames() string {
+	names := make([]string, 0, len(SortExtToInt))
+	for name := range SortExtToInt {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 func exportEnc(enc encoding.Encoder) (string, error) {

--- a/specs/builder_test.go
+++ b/specs/builder_test.go
@@ -662,3 +662,57 @@ func TestExportImportEBCDIC1047Encoding(t *testing.T) {
 	require.NoError(t, err)
 	require.Exactly(t, spec, fromJSON)
 }
+
+// A sort function the importer cannot resolve used to be exported by name and
+// then rejected on the way back in, so the round trip produced a document that
+// looked complete and would not load. The export is where a developer can still
+// do something about it.
+func TestExportRejectsASortTheImportCannotResolve(t *testing.T) {
+	custom := func(x []string) { _ = x }
+
+	spec := &iso8583.MessageSpec{
+		Name: "custom sort",
+		Fields: map[int]field.Field{
+			0: field.NewString(&field.Spec{Length: 4, Description: "MTI", Enc: encoding.ASCII, Pref: prefix.ASCII.Fixed}),
+			1: field.NewBitmap(&field.Spec{Description: "Bitmap", Enc: encoding.BytesToASCIIHex, Pref: prefix.Hex.Fixed}),
+			3: field.NewComposite(&field.Spec{
+				Length: 2, Description: "Composite", Pref: prefix.ASCII.Fixed,
+				Tag:       &field.TagSpec{Sort: custom},
+				Subfields: map[string]field.Field{"1": field.NewString(&field.Spec{Length: 2, Description: "a", Enc: encoding.ASCII, Pref: prefix.ASCII.Fixed})},
+			}),
+		},
+	}
+
+	_, err := ExportYAML(spec)
+	require.Error(t, err, "a spec whose sort cannot be resolved was exported anyway")
+	require.Contains(t, err.Error(), "unknown sort function")
+	require.Contains(t, err.Error(), "StringsByInt", "the error does not say which names are exportable")
+
+	_, err = ExportJSON(spec)
+	require.Error(t, err, "JSON export accepted what YAML export refused")
+}
+
+// The registered ones still export, and still come back.
+func TestAKnownSortStillRoundTrips(t *testing.T) {
+	spec := &iso8583.MessageSpec{
+		Name: "known sort",
+		Fields: map[int]field.Field{
+			0: field.NewString(&field.Spec{Length: 4, Description: "MTI", Enc: encoding.ASCII, Pref: prefix.ASCII.Fixed}),
+			1: field.NewBitmap(&field.Spec{Description: "Bitmap", Enc: encoding.BytesToASCIIHex, Pref: prefix.Hex.Fixed}),
+			3: field.NewComposite(&field.Spec{
+				Length: 2, Description: "Composite", Pref: prefix.ASCII.Fixed,
+				Tag:       &field.TagSpec{Sort: sort.StringsByInt},
+				Subfields: map[string]field.Field{"1": field.NewString(&field.Spec{Length: 2, Description: "a", Enc: encoding.ASCII, Pref: prefix.ASCII.Fixed})},
+			}),
+		},
+	}
+
+	out, err := ExportYAML(spec)
+	require.NoError(t, err)
+
+	back, err := ImportYAML(out)
+	require.NoError(t, err, "a spec this package exported could not be imported")
+	composite, ok := back.Fields[3].(*field.Composite)
+	require.True(t, ok)
+	require.Len(t, composite.Spec().Subfields, 1)
+}


### PR DESCRIPTION
A document stores a sort function by name. The importer resolves only the two names in `SortExtToInt`. Exporting a spec that uses any other one succeeds today, and writes the function's Go name into the file. The failure appears later, on import, as `unknown sort function` against a file that looks complete.

So the round trip this package offers has a hole in it. A spec goes out and cannot come back. Nothing says so at the point where a developer can still act on it.

## The change

`exportSort` checks the name against the same map the importer uses, and the error says which names are exportable:

```
failed to export field: 3. unknown sort function: sortByPriority; only StringsByHex, StringsByInt can be exported, because those are the ones an import can resolve
```

This follows `exportEnc`, which already fails when it cannot represent an encoding.

## Tests

`TestExportRejectsASortTheImportCannotResolve` covers a custom sort refused by both `ExportYAML` and `ExportJSON`, and `TestAKnownSortStillRoundTrips` pins that a registered one still exports and imports back with its subfields.

## Scope

- A spec whose sort is one of the two registered ones exports exactly as before.
- Nothing on the import side changes.

Sibling of #448, which is the same boundary from the other direction. There, a malformed document panics instead of returning an error. Here, the exporter writes out a spec it cannot represent instead of refusing it.

🤖 Claude Opus 5

